### PR TITLE
add prefix & suffix options.

### DIFF
--- a/gulp-css2js.js
+++ b/gulp-css2js.js
@@ -154,12 +154,15 @@
         fallback('trimSpacesBeforeNewline', true);
         fallback('trimTrailingNewline', true);
 
+        var curPrefixBuffer = options.prefix ? new Buffer(options.prefix, 'utf8') : prefixBuffer;
+        var curSuffixBuffer = options.suffix ? new Buffer(options.suffix, 'utf8') : suffixBuffer;
+
         return through2.obj(function (file, encoding, callback) {
             if (file.isBuffer()) {
                 file.contents = Buffer.concat([
-                    prefixBuffer,
+                    curPrefixBuffer,
                     escapeBuffer(file.contents, encoding, options),
-                    suffixBuffer
+                    curSuffixBuffer
                 ]);
                 file.path = gulpUtil.replaceExtension(file.path, ".js");
             } else if (file.isStream()) {

--- a/test/unit.js
+++ b/test/unit.js
@@ -184,6 +184,21 @@ describe('gulp-css2js', function () {
                 }, done);
             });
         });
+        describe('prefix and suffix', function () {
+            var input, output, prefix, suffix;
+
+            input = 'div { display: block }';
+            output = 'var a = "div { display: block }";';
+            prefix = 'var a = "';
+            suffix = '";';
+
+            it('is true', function (done) {
+                runThroughStream(makeFile(output, 'test/styles/testing.js'), makeFile(input), {
+                    prefix: prefix,
+                    suffix: suffix
+                }, done);
+            });
+        });
     });
     describe('escaping', function () {
         it('escapes as necessary', function (done) {


### PR DESCRIPTION
Sometimes, the expect `output` is like this:

``` js
var cssText = "body { color: red }";
```

so, I added `prefix` and `suffix` options.
