### PR TITLE
Minify default wrapper

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "plugins": [
+        "preval"
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ nbproject/
 
 # Generated
 /node_modules/
+dist/

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+assets/
 src/
 test/
 .babelrc

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+src/
+test/
+.babelrc
+.editorconfig
+.gitignore
+.travis.yml

--- a/assets/defaultWrapper.js
+++ b/assets/defaultWrapper.js
@@ -1,0 +1,21 @@
+/**
+ * This code is used for the default prefix and suffix.
+ * It is minified with uglify-js during the build step.
+ * It is split into prefix and suffix by the $$$ bit.
+ * It should stay written in ES5.
+ */
+(function (doc, cssText) {
+    var styleEl = doc.createElement("style");
+    doc.getElementsByTagName("head")[0].appendChild(styleEl);
+    if (styleEl.styleSheet) {
+        if (!styleEl.styleSheet.disabled) {
+            styleEl.styleSheet.cssText = cssText;
+        }
+    } else {
+        try {
+            styleEl.innerHTML = cssText;
+        } catch (ignore) {
+            styleEl.innerText = cssText;
+        }
+    }
+}(document, "$$$"));

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
         "url": "https://github.com/tests-always-included/gulp-css2js/issues"
     },
     "contributors": [
-        "Tyler Akins <fidian@rumkin.com> (http://rumkin.com)"
+        "Tyler Akins <fidian@rumkin.com> (http://rumkin.com)",
+        "Matthew Francis Brunetti <zenflow87@gmail.com>"
     ],
-    "main": "gulp-css2js.js",
+    "main": "dist/gulp-css2js.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/tests-always-included/gulp-css2js.git"
@@ -24,14 +25,22 @@
         "through2": "*"
     },
     "devDependencies": {
-        "mocha": "*",
-        "slash": "^1.0.0"
+        "@babel/cli": "^7.0.0-beta.38",
+        "@babel/core": "^7.0.0-beta.38",
+        "@babel/register": "^7.0.0-beta.38",
+        "babel-plugin-preval": "^1.6.3",
+        "mocha": ">=4.0.0",
+        "rimraf": "^2.6.2",
+        "slash": "^1.0.0",
+        "uglify-js": "^3.3.8"
     },
     "license": "MIT",
     "engines": {
         "node": ">=0.9"
     },
     "scripts": {
-        "test": "mocha"
+        "test": "mocha --require @babel/register",
+        "build": "rimraf dist && babel src --out-dir dist",
+        "prepublish": "npm run build"
     }
 }

--- a/src/gulp-css2js.js
+++ b/src/gulp-css2js.js
@@ -13,7 +13,7 @@
 (function () {
     'use strict';
 
-    var defaultOptions, gulpUtil, through2;
+    var defaultOptions, gulpUtil, through2, defaultWrapper;
 
     /**
      * @typedef {Object} gulpCss2js~options
@@ -201,24 +201,23 @@
         });
     };
 
+    /* The following `preval` expression is evaluated and replaced at build-time.
+     * (For more on that, see https://github.com/kentcdodds/babel-plugin-preval)
+     * See assets/defaultWrapper.js for the unminified version of `defaultWrapper`.
+     */
+    defaultWrapper = preval`
+        const fs = require('fs');
+        const path = require('path');
+        const uglifyJs = require('uglify-js');
+        const prettyWrapper = fs.readFileSync(path.join(__dirname, '../assets/defaultWrapper.js'), 'utf8');
+        const uglyWrapper = uglifyJs.minify(prettyWrapper).code;
+        module.exports = uglyWrapper.split('$$$');
+    `;
+
     module.exports.defaultOptions = defaultOptions = {
-        prefix: '(function (doc, cssText) {\n' +
-            '    var styleEl = doc.createElement("style");\n' +
-            '    doc.getElementsByTagName("head")[0].appendChild(styleEl);\n' +
-            '    if (styleEl.styleSheet) {\n' +
-            '        if (!styleEl.styleSheet.disabled) {\n' +
-            '            styleEl.styleSheet.cssText = cssText;\n' +
-            '        }\n' +
-            '    } else {\n' +
-            '        try {\n' +
-            '            styleEl.innerHTML = cssText;\n' +
-            '        } catch (ignore) {\n' +
-            '            styleEl.innerText = cssText;\n' +
-            '        }\n' +
-            '    }\n' +
-            '}(document, "',
+        prefix: defaultWrapper[0],
+        suffix: defaultWrapper[1],
         splitOnNewline: true,
-        suffix: '"));\n',
         trimSpacesBeforeNewline: true,
         trimTrailingNewline: true
     };

--- a/test/unit.js
+++ b/test/unit.js
@@ -9,7 +9,7 @@
 var Assert, css2js, defaultOptions, gulpUtil, stream, slash;
 
 Assert = require('assert');
-css2js = require('../');
+css2js = require('../src/gulp-css2js');
 defaultOptions = JSON.parse(JSON.stringify(css2js.defaultOptions));
 gulpUtil = require('gulp-util');
 stream = require('stream');

--- a/test/unit.js
+++ b/test/unit.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-var Assert, css2js, defaultOptions, gulpUtil, stream, slash;
+var Assert, css2js, defaultOptions, gulpUtil, stream, slash, fs, path;
 
 Assert = require('assert');
 css2js = require('../src/gulp-css2js');
@@ -16,6 +16,8 @@ stream = require('stream');
 // The 'slash' package is used to normalize paths in respect to OS/environment...
 //   e.g. change '.\\foo\\bar' (Windows path) to the expected './foo/bar' (*nix path)
 slash = require('slash');
+fs = require('fs');
+path = require('path');
 
 function runThroughStream(expected, srcFile, options, done) {
     var stream;
@@ -258,6 +260,16 @@ describe('gulp-css2js', function () {
                     }, done);
                 });
             });
+            describe('default wrapper', function () {
+                it('is minified', function () {
+                    var originalWrapper, effectiveWrapper;
+
+                    originalWrapper = fs.readFileSync(path.join(__dirname, '../assets/defaultWrapper.js'), 'utf8');
+                    effectiveWrapper = css2js.defaultOptions.prefix + '$$$' + css2js.defaultOptions.suffix;
+
+                    Assert.ok(effectiveWrapper.length < originalWrapper.length / 2);
+                })
+            })
         });
     });
 });


### PR DESCRIPTION
Resolves issue #2 

So I based my work off of my branch for PR #3 .. If there's any problem with that I can rebase this onto master.

As requested, the build process is fairly transparent, in that you would barely notice it; it generally just happens automatically when it should, without having to worry about it: 

- I added a "prepublish" script to the package so you don't have to worry to manually run the build before publishing (note this also gets run when you `npm install` the package for development)
- The build process is incorporated into the package test script, which doesn't rely on the new `dist` folder
- Just remember to manually run `npm run build` if you make changes and want to test them in some other way (like `npm link`ing it into some other project, or using node's REPL)

I held off on configuring babel to transpile es-next to es5, since we're not going to use es-next yet (with the exception of my use of 1 template string that gets replaced by preval). When the time comes to transpile es-next, you can...

1. `npm install -D @babel/preset-env@^7.0.0-beta.38`
2. Merge this into the `.babelrc`
```json
{
    "presets": [
        ["@babel/preset-env", {
            "targets": {
                "node": "0.9"
            }
        }]
    ]
}
```
3. Maybe try out [lebab](https://github.com/lebab/lebab) ("babel" backwards) to semi-automate upgrading the source code, and let me know how it goes!