### PR TITLE
Support SSR by not failing if document is undefined

### DIFF
--- a/assets/defaultWrapper.js
+++ b/assets/defaultWrapper.js
@@ -4,18 +4,20 @@
  * It is split into prefix and suffix by the $$$ bit.
  * It should stay written in ES5.
  */
-(function (doc, cssText) {
-    var styleEl = doc.createElement("style");
-    doc.getElementsByTagName("head")[0].appendChild(styleEl);
-    if (styleEl.styleSheet) {
-        if (!styleEl.styleSheet.disabled) {
-            styleEl.styleSheet.cssText = cssText;
+if (typeof document !== 'undefined') {
+    (function (doc, cssText) {
+        var styleEl = doc.createElement("style");
+        doc.getElementsByTagName("head")[0].appendChild(styleEl);
+        if (styleEl.styleSheet) {
+            if (!styleEl.styleSheet.disabled) {
+                styleEl.styleSheet.cssText = cssText;
+            }
+        } else {
+            try {
+                styleEl.innerHTML = cssText;
+            } catch (ignore) {
+                styleEl.innerText = cssText;
+            }
         }
-    } else {
-        try {
-            styleEl.innerHTML = cssText;
-        } catch (ignore) {
-            styleEl.innerText = cssText;
-        }
-    }
-}(document, "$$$"));
+    }(document, "$$$"));
+}


### PR DESCRIPTION
Recently we've started using `gulp-css2js` for building [SweetAlert2](https://github.com/sweetalert2/sweetalert2)

We got the regression report: https://github.com/sweetalert2/sweetalert2/issues/996

This change should add SSR support for this plugin by not throwing the exception in environments w/o `document` present.