### PR TITLE
Fix tests failing on node v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gulp-css2js",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/cli": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/cli/-/cli-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.38.tgz",
             "integrity": "sha512-RF2RQh9gvxeXtwrFzgf4PKCsmCPsa/tHaL0TQ3eWRoyno91GsoYnAhh/SnvPrlvXV+9Uosw+zwOgwnVyRvPDYQ==",
             "dev": true,
             "requires": {
@@ -23,7 +23,7 @@
         },
         "@babel/code-frame": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
             "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
             "dev": true,
             "requires": {
@@ -65,7 +65,7 @@
         },
         "@babel/core": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/core/-/core-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.38.tgz",
             "integrity": "sha512-xIDdSeSElby0p6QMowawWrU9VulpMk1yq6RaKYjaZBRT7s40kztTsDw8+VUVuQmdRbqLh8DpLWs15oaUWphsPg==",
             "dev": true,
             "requires": {
@@ -87,7 +87,7 @@
         },
         "@babel/generator": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/generator/-/generator-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.38.tgz",
             "integrity": "sha512-aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==",
             "dev": true,
             "requires": {
@@ -100,7 +100,7 @@
         },
         "@babel/helper-function-name": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
             "integrity": "sha512-vLOtqh2PMbvOXL/+DlwH6A2/y+81l518Z0x7232T4E8HiMBQbkv3rNg4GmjJ5M6GcZzj7UKTBrVt8AXcH4OTdA==",
             "dev": true,
             "requires": {
@@ -111,7 +111,7 @@
         },
         "@babel/helper-get-function-arity": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
             "integrity": "sha512-ty3muWaxHPcvdwihBWqGBD+s+hjt4Tua3In43eA4BvLMKWtTYsJBGdLoWQUY4TXhVgDe7wPzqxIv2AUbnIh/vQ==",
             "dev": true,
             "requires": {
@@ -120,7 +120,7 @@
         },
         "@babel/helpers": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
             "integrity": "sha512-DNdEZABrx2oNSpqijJHjxR/V36hMIQgFkdgv/iQsJ7xhXhObIrH1FMXsd3jbnlgblTc/7/hYed6wNKYxxXX0eQ==",
             "dev": true,
             "requires": {
@@ -131,7 +131,7 @@
         },
         "@babel/register": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/register/-/register-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.38.tgz",
             "integrity": "sha512-szE2vMZ8FB6NkywESqDGcAtchQafaWLQgJo3xro7GIgNRmJoAX2xZijU1e5AKT4zWkRRc53aBBwfZy03aWsPgw==",
             "dev": true,
             "requires": {
@@ -146,7 +146,7 @@
         },
         "@babel/template": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/template/-/template-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.38.tgz",
             "integrity": "sha512-ygOSe1+ekKVkn5zxCH0rqv5sZtvLfC72yPQSaXLTHtYSYdAyXNqOW7q1ua1zJll9glk0UWYAnUEcehQXXc3fEA==",
             "dev": true,
             "requires": {
@@ -158,7 +158,7 @@
         },
         "@babel/traverse": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
             "integrity": "sha512-qbrc59aPCnMCj3uroG7QXdFMmrFLFvEfcwfVzmF2MXh2a7OhRzs73g/PNN8Xb0W/4Z1H4ZTY95CczmfDmXapnw==",
             "dev": true,
             "requires": {
@@ -175,7 +175,7 @@
         },
         "@babel/types": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/types/-/types-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.38.tgz",
             "integrity": "sha512-SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==",
             "dev": true,
             "requires": {
@@ -186,7 +186,7 @@
         },
         "ansi-gray": {
             "version": "0.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
             "requires": {
                 "ansi-wrap": "0.1.0"
@@ -194,22 +194,22 @@
         },
         "ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "2.2.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "ansi-wrap": {
             "version": "0.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "anymatch": {
             "version": "1.3.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/anymatch/-/anymatch-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "optional": true,
@@ -229,7 +229,7 @@
         },
         "arr-diff": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/arr-diff/-/arr-diff-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
@@ -238,36 +238,36 @@
         },
         "arr-flatten": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "array-differ": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-differ/-/array-differ-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-uniq": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-uniq/-/array-uniq-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
         },
         "array-unique": {
             "version": "0.2.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-unique/-/array-unique-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true
         },
         "async-each": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/async-each/-/async-each-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
             "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
             "dev": true,
             "optional": true
         },
         "babel-code-frame": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
@@ -278,7 +278,7 @@
         },
         "babel-core": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-core/-/babel-core-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
             "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
             "dev": true,
             "requires": {
@@ -305,7 +305,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 },
@@ -338,7 +338,7 @@
             "dependencies": {
                 "jsesc": {
                     "version": "1.3.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/jsesc/-/jsesc-1.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
                     "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
                     "dev": true
                 }
@@ -346,7 +346,7 @@
         },
         "babel-helpers": {
             "version": "6.24.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
@@ -356,7 +356,7 @@
         },
         "babel-messages": {
             "version": "6.23.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-messages/-/babel-messages-6.23.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
@@ -386,7 +386,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 }
@@ -394,7 +394,7 @@
         },
         "babel-register": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-register/-/babel-register-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
@@ -409,7 +409,7 @@
             "dependencies": {
                 "home-or-tmp": {
                     "version": "2.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
                     "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
                     "dev": true,
                     "requires": {
@@ -421,7 +421,7 @@
         },
         "babel-runtime": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
@@ -431,7 +431,7 @@
         },
         "babel-template": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-template/-/babel-template-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
@@ -444,7 +444,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 }
@@ -452,7 +452,7 @@
         },
         "babel-traverse": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
@@ -469,7 +469,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 },
@@ -484,7 +484,7 @@
                 },
                 "globals": {
                     "version": "9.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/globals/-/globals-9.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
                     "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
                     "dev": true
                 }
@@ -492,7 +492,7 @@
         },
         "babel-types": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-types/-/babel-types-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
@@ -504,7 +504,7 @@
             "dependencies": {
                 "to-fast-properties": {
                     "version": "1.0.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                     "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
                     "dev": true
                 }
@@ -512,31 +512,31 @@
         },
         "babylon": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-7.0.0-beta.38.tgz",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.38.tgz",
             "integrity": "sha512-ukc+RoVsxNjsFGTgXtCGr/RcNHQ4/OKBZQ2B6C2XBQwrbxXGWxgOMF9xgQ2WAQJQtvur3N6xakpIGMRNfGtt8Q==",
             "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/balanced-match/-/balanced-match-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
         "beeper": {
             "version": "1.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/beeper/-/beeper-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
             "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
         },
         "binary-extensions": {
             "version": "1.11.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/binary-extensions/-/binary-extensions-1.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
             "dev": true,
             "optional": true
         },
         "brace-expansion": {
             "version": "1.1.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
@@ -546,7 +546,7 @@
         },
         "braces": {
             "version": "1.8.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/braces/-/braces-1.8.5.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
@@ -557,13 +557,13 @@
         },
         "browser-stdout": {
             "version": "1.3.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
         },
         "chalk": {
             "version": "1.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chalk/-/chalk-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
                 "ansi-styles": "2.2.1",
@@ -575,13 +575,14 @@
         },
         "chokidar": {
             "version": "1.7.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chokidar/-/chokidar-1.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "optional": true,
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
+                "fsevents": "1.1.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -592,17 +593,17 @@
         },
         "clone": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/clone/-/clone-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
             "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
         },
         "clone-stats": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/clone-stats/-/clone-stats-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
             "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "color-convert": {
             "version": "1.9.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-convert/-/color-convert-1.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
@@ -611,48 +612,48 @@
         },
         "color-name": {
             "version": "1.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "color-support": {
             "version": "1.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-support/-/color-support-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
         },
         "commander": {
             "version": "2.11.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commander/-/commander-2.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
             "dev": true
         },
         "commondir": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commondir/-/commondir-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
         "convert-source-map": {
             "version": "1.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
             "dev": true
         },
         "core-js": {
             "version": "2.5.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/core-js/-/core-js-2.5.3.tgz",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
             "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
             "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cosmiconfig": {
@@ -669,7 +670,7 @@
         },
         "dateformat": {
             "version": "2.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/dateformat/-/dateformat-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
             "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "debug": {
@@ -683,7 +684,7 @@
         },
         "detect-indent": {
             "version": "4.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/detect-indent/-/detect-indent-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
@@ -692,13 +693,13 @@
         },
         "diff": {
             "version": "3.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/diff/-/diff-3.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
             "dev": true
         },
         "duplexer2": {
             "version": "0.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/duplexer2/-/duplexer2-0.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "requires": {
                 "readable-stream": "1.1.14"
@@ -706,7 +707,7 @@
         },
         "error-ex": {
             "version": "1.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/error-ex/-/error-ex-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
@@ -715,24 +716,24 @@
         },
         "escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "esprima": {
             "version": "4.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/esprima/-/esprima-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
             "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
             "dev": true
         },
         "esutils": {
             "version": "2.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/esutils/-/esutils-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "expand-brackets": {
             "version": "0.1.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
@@ -741,7 +742,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -750,7 +751,7 @@
         },
         "extglob": {
             "version": "0.3.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/extglob/-/extglob-0.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
@@ -759,7 +760,7 @@
         },
         "fancy-log": {
             "version": "1.3.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fancy-log/-/fancy-log-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
                 "ansi-gray": "0.1.1",
@@ -769,13 +770,13 @@
         },
         "filename-regex": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/filename-regex/-/filename-regex-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
             "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
             "dev": true
         },
         "fill-range": {
             "version": "2.2.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fill-range/-/fill-range-2.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
@@ -788,7 +789,7 @@
         },
         "find-cache-dir": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
@@ -799,7 +800,7 @@
         },
         "find-up": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/find-up/-/find-up-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
@@ -808,13 +809,13 @@
         },
         "for-in": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/for-in/-/for-in-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
         "for-own": {
             "version": "0.1.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/for-own/-/for-own-0.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
@@ -823,19 +824,923 @@
         },
         "fs-readdir-recursive": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
             "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
             "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.9.2",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
         "glob": {
             "version": "7.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob/-/glob-7.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
@@ -849,7 +1754,7 @@
         },
         "glob-base": {
             "version": "0.3.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob-base/-/glob-base-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
@@ -859,7 +1764,7 @@
         },
         "glob-parent": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob-parent/-/glob-parent-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
@@ -874,7 +1779,7 @@
         },
         "glogg": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glogg/-/glogg-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
                 "sparkles": "1.0.0"
@@ -882,19 +1787,19 @@
         },
         "graceful-fs": {
             "version": "4.1.11",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
             "dev": true
         },
         "growl": {
             "version": "1.10.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/growl/-/growl-1.10.3.tgz",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
             "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
             "dev": true
         },
         "gulp-util": {
             "version": "3.0.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/gulp-util/-/gulp-util-3.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "requires": {
                 "array-differ": "1.0.0",
@@ -919,7 +1824,7 @@
         },
         "gulplog": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/gulplog/-/gulplog-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
                 "glogg": "1.0.1"
@@ -927,7 +1832,7 @@
         },
         "has-ansi": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-ansi/-/has-ansi-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
                 "ansi-regex": "2.1.1"
@@ -935,13 +1840,13 @@
         },
         "has-flag": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-flag/-/has-flag-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
         "has-gulplog": {
             "version": "0.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "requires": {
                 "sparkles": "1.0.0"
@@ -949,19 +1854,19 @@
         },
         "he": {
             "version": "1.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/he/-/he-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
         "home-or-tmp": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
             "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
             "dev": true
         },
         "inflight": {
             "version": "1.0.6",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
@@ -971,7 +1876,7 @@
         },
         "inherits": {
             "version": "2.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/inherits/-/inherits-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "invariant": {
@@ -985,13 +1890,13 @@
         },
         "is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
         "is-binary-path": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "optional": true,
@@ -1001,25 +1906,25 @@
         },
         "is-buffer": {
             "version": "1.1.6",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-buffer/-/is-buffer-1.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-directory": {
             "version": "0.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-directory/-/is-directory-0.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
             "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
             "dev": true
         },
         "is-dotfile": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
             "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
             "dev": true
         },
         "is-equal-shallow": {
             "version": "0.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
@@ -1028,19 +1933,19 @@
         },
         "is-extendable": {
             "version": "0.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-extendable/-/is-extendable-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
         "is-extglob": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-extglob/-/is-extglob-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
             "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
             "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-finite/-/is-finite-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
@@ -1049,7 +1954,7 @@
         },
         "is-glob": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-glob/-/is-glob-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
@@ -1058,7 +1963,7 @@
         },
         "is-number": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-number/-/is-number-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
@@ -1067,30 +1972,30 @@
         },
         "is-plain-obj": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
         "is-posix-bracket": {
             "version": "0.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
             "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
             "dev": true
         },
         "is-primitive": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-primitive/-/is-primitive-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
             "dev": true
         },
         "isarray": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "isobject": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isobject/-/isobject-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
             "requires": {
@@ -1099,7 +2004,7 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 }
@@ -1107,7 +2012,7 @@
         },
         "js-tokens": {
             "version": "3.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/js-tokens/-/js-tokens-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
@@ -1123,19 +2028,19 @@
         },
         "jsesc": {
             "version": "2.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/jsesc/-/jsesc-2.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
             "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
             "dev": true
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/json5/-/json5-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
         "kind-of": {
             "version": "3.2.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-3.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
@@ -1144,7 +2049,7 @@
         },
         "locate-path": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/locate-path/-/locate-path-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
@@ -1160,52 +2065,52 @@
         },
         "lodash._basecopy": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
             "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
         },
         "lodash._basetostring": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
             "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
         },
         "lodash._basevalues": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
             "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
         },
         "lodash._getnative": {
             "version": "3.9.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
             "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
         "lodash._isiterateecall": {
             "version": "3.0.9",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
             "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
         },
         "lodash._reescape": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
             "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
         },
         "lodash._reevaluate": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
             "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
         },
         "lodash._root": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._root/-/lodash._root-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
         "lodash.escape": {
             "version": "3.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "requires": {
                 "lodash._root": "3.0.1"
@@ -1213,17 +2118,17 @@
         },
         "lodash.isarguments": {
             "version": "3.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
             "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
         },
         "lodash.isarray": {
             "version": "3.0.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
         },
         "lodash.keys": {
             "version": "3.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "requires": {
                 "lodash._getnative": "3.9.1",
@@ -1233,12 +2138,12 @@
         },
         "lodash.restparam": {
             "version": "3.6.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
             "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
         },
         "lodash.template": {
             "version": "3.6.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.template/-/lodash.template-3.6.2.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "requires": {
                 "lodash._basecopy": "3.0.1",
@@ -1254,7 +2159,7 @@
         },
         "lodash.templatesettings": {
             "version": "3.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "requires": {
                 "lodash._reinterpolate": "3.0.0",
@@ -1263,7 +2168,7 @@
         },
         "loose-envify": {
             "version": "1.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/loose-envify/-/loose-envify-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
@@ -1281,7 +2186,7 @@
         },
         "micromatch": {
             "version": "2.3.11",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/micromatch/-/micromatch-2.3.11.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
@@ -1302,7 +2207,7 @@
         },
         "minimatch": {
             "version": "3.0.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimatch/-/minimatch-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
@@ -1311,12 +2216,12 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -1325,16 +2230,16 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimist/-/minimist-0.0.8.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 }
             }
         },
         "mocha": {
-            "version": "5.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/mocha/-/mocha-5.0.0.tgz",
-            "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
             "dev": true,
             "requires": {
                 "browser-stdout": "1.3.0",
@@ -1351,7 +2256,7 @@
             "dependencies": {
                 "supports-color": {
                     "version": "4.4.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-4.4.0.tgz",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
@@ -1362,27 +2267,34 @@
         },
         "ms": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
         "multipipe": {
             "version": "0.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/multipipe/-/multipipe-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
             "requires": {
                 "duplexer2": "0.0.2"
             }
         },
+        "nan": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+            "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+            "dev": true,
+            "optional": true
+        },
         "node-modules-regexp": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
             "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
             "dev": true
         },
         "normalize-path": {
             "version": "2.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/normalize-path/-/normalize-path-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
@@ -1391,18 +2303,18 @@
         },
         "number-is-nan": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
         "object-assign": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/object-assign/-/object-assign-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
             "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "object.omit": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/object.omit/-/object.omit-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
@@ -1412,7 +2324,7 @@
         },
         "once": {
             "version": "1.4.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/once/-/once-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
@@ -1421,13 +2333,13 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -1444,7 +2356,7 @@
         },
         "p-limit": {
             "version": "1.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-limit/-/p-limit-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
@@ -1453,7 +2365,7 @@
         },
         "p-locate": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-locate/-/p-locate-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
@@ -1462,13 +2374,13 @@
         },
         "p-try": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-try/-/p-try-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
         "parse-glob": {
             "version": "3.0.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/parse-glob/-/parse-glob-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
@@ -1489,31 +2401,31 @@
         },
         "path-exists": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-exists/-/path-exists-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
         "path-parse": {
             "version": "1.0.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-parse/-/path-parse-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
             "dev": true
         },
         "pify": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pify/-/pify-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
         "pirates": {
             "version": "3.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pirates/-/pirates-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
             "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
             "dev": true,
             "requires": {
@@ -1522,7 +2434,7 @@
         },
         "pkg-dir": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
@@ -1531,24 +2443,24 @@
         },
         "preserve": {
             "version": "0.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/preserve/-/preserve-0.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
             "dev": true
         },
         "private": {
             "version": "0.1.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/private/-/private-0.1.8.tgz",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
             "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
         "process-nextick-args": {
             "version": "1.0.7",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "randomatic": {
             "version": "1.1.7",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/randomatic/-/randomatic-1.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
@@ -1558,7 +2470,7 @@
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
@@ -1567,7 +2479,7 @@
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
@@ -1578,7 +2490,7 @@
                 },
                 "kind-of": {
                     "version": "4.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
@@ -1589,7 +2501,7 @@
         },
         "readable-stream": {
             "version": "1.1.14",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-1.1.14.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
             "requires": {
                 "core-util-is": "1.0.2",
@@ -1600,7 +2512,7 @@
         },
         "readdirp": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readdirp/-/readdirp-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "optional": true,
@@ -1613,7 +2525,7 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true,
                     "optional": true
@@ -1636,7 +2548,7 @@
                 },
                 "string_decoder": {
                     "version": "1.0.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "optional": true,
@@ -1648,13 +2560,13 @@
         },
         "regenerator-runtime": {
             "version": "0.11.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
             "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
             "dev": true
         },
         "regex-cache": {
             "version": "0.4.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/regex-cache/-/regex-cache-0.4.4.tgz",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
@@ -1663,25 +2575,25 @@
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
         },
         "repeat-element": {
             "version": "1.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeat-element/-/repeat-element-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
             "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
             "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeat-string/-/repeat-string-1.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
         "repeating": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeating/-/repeating-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
@@ -1690,18 +2602,18 @@
         },
         "replace-ext": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/replace-ext/-/replace-ext-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "require-from-string": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/require-from-string/-/require-from-string-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
             "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
             "dev": true
         },
         "resolve": {
             "version": "1.5.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/resolve/-/resolve-1.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
@@ -1710,7 +2622,7 @@
         },
         "rimraf": {
             "version": "2.6.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/rimraf/-/rimraf-2.6.2.tgz",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
@@ -1719,31 +2631,31 @@
         },
         "safe-buffer": {
             "version": "5.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "set-immediate-shim": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "dev": true,
             "optional": true
         },
         "slash": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/slash/-/slash-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
             "dev": true
         },
         "source-map": {
             "version": "0.5.7",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map/-/source-map-0.5.7.tgz",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
         "source-map-support": {
             "version": "0.4.18",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map-support/-/source-map-support-0.4.18.tgz",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
@@ -1752,23 +2664,23 @@
         },
         "sparkles": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/sparkles/-/sparkles-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
             "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "string_decoder": {
             "version": "0.10.31",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-0.10.31.tgz",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "2.1.1"
@@ -1776,12 +2688,12 @@
         },
         "supports-color": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "through2": {
             "version": "2.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/through2/-/through2-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
                 "readable-stream": "2.3.3",
@@ -1790,12 +2702,12 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "readable-stream": {
                     "version": "2.3.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "requires": {
                         "core-util-is": "1.0.2",
@@ -1809,7 +2721,7 @@
                 },
                 "string_decoder": {
                     "version": "1.0.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "requires": {
                         "safe-buffer": "5.1.1"
@@ -1819,18 +2731,18 @@
         },
         "time-stamp": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/time-stamp/-/time-stamp-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
         },
         "to-fast-properties": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/trim-right/-/trim-right-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
@@ -1852,7 +2764,7 @@
                 },
                 "source-map": {
                     "version": "0.6.1",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map/-/source-map-0.6.1.tgz",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
@@ -1860,12 +2772,12 @@
         },
         "util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vinyl": {
             "version": "0.5.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/vinyl/-/vinyl-0.5.3.tgz",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "requires": {
                 "clone": "1.0.3",
@@ -1875,13 +2787,13 @@
         },
         "wrappy": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
         "xtend": {
             "version": "4.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/xtend/-/xtend-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "gulp-css2js",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/cli": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/cli/-/cli-7.0.0-beta.38.tgz",
-            "integrity": "sha512-RF2RQh9gvxeXtwrFzgf4PKCsmCPsa/tHaL0TQ3eWRoyno91GsoYnAhh/SnvPrlvXV+9Uosw+zwOgwnVyRvPDYQ==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.40.tgz",
+            "integrity": "sha512-7f2pWUlklOYn5USkVPlDw1yX71WsgP8EG7CTn17j4ydtGnYtD+nptTMM4J3EaRgILOgfesVkSOV+lIOnUVOAlg==",
             "dev": true,
             "requires": {
                 "chokidar": "1.7.0",
@@ -16,66 +16,33 @@
                 "fs-readdir-recursive": "1.1.0",
                 "glob": "7.1.2",
                 "lodash": "4.17.4",
-                "output-file-sync": "2.0.0",
+                "output-file-sync": "2.0.1",
                 "slash": "1.0.0",
                 "source-map": "0.5.7"
             }
         },
         "@babel/code-frame": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
-            "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+            "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.0",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
+                "@babel/highlight": "7.0.0-beta.40"
             }
         },
         "@babel/core": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/core/-/core-7.0.0-beta.38.tgz",
-            "integrity": "sha512-xIDdSeSElby0p6QMowawWrU9VulpMk1yq6RaKYjaZBRT7s40kztTsDw8+VUVuQmdRbqLh8DpLWs15oaUWphsPg==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.40.tgz",
+            "integrity": "sha512-jJMjn/EMg89xDGv7uq4BoFg+fHEchSeqNc9YUMnGuAi/FWKBkSsDbhh2y5euw4qaGOFD2jw1le0rvCu5gPUc6Q==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.38",
-                "@babel/generator": "7.0.0-beta.38",
-                "@babel/helpers": "7.0.0-beta.38",
-                "@babel/template": "7.0.0-beta.38",
-                "@babel/traverse": "7.0.0-beta.38",
-                "@babel/types": "7.0.0-beta.38",
-                "babylon": "7.0.0-beta.38",
+                "@babel/code-frame": "7.0.0-beta.40",
+                "@babel/generator": "7.0.0-beta.40",
+                "@babel/helpers": "7.0.0-beta.40",
+                "@babel/template": "7.0.0-beta.40",
+                "@babel/traverse": "7.0.0-beta.40",
+                "@babel/types": "7.0.0-beta.40",
+                "babylon": "7.0.0-beta.40",
                 "convert-source-map": "1.5.1",
                 "debug": "3.1.0",
                 "json5": "0.5.1",
@@ -86,12 +53,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/generator/-/generator-7.0.0-beta.38.tgz",
-            "integrity": "sha512-aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
+            "integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.38",
+                "@babel/types": "7.0.0-beta.40",
                 "jsesc": "2.5.1",
                 "lodash": "4.17.4",
                 "source-map": "0.5.7",
@@ -99,40 +66,88 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
-            "integrity": "sha512-vLOtqh2PMbvOXL/+DlwH6A2/y+81l518Z0x7232T4E8HiMBQbkv3rNg4GmjJ5M6GcZzj7UKTBrVt8AXcH4OTdA==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
+            "integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.38",
-                "@babel/template": "7.0.0-beta.38",
-                "@babel/types": "7.0.0-beta.38"
+                "@babel/helper-get-function-arity": "7.0.0-beta.40",
+                "@babel/template": "7.0.0-beta.40",
+                "@babel/types": "7.0.0-beta.40"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
-            "integrity": "sha512-ty3muWaxHPcvdwihBWqGBD+s+hjt4Tua3In43eA4BvLMKWtTYsJBGdLoWQUY4TXhVgDe7wPzqxIv2AUbnIh/vQ==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
+            "integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.38"
+                "@babel/types": "7.0.0-beta.40"
             }
         },
         "@babel/helpers": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
-            "integrity": "sha512-DNdEZABrx2oNSpqijJHjxR/V36hMIQgFkdgv/iQsJ7xhXhObIrH1FMXsd3jbnlgblTc/7/hYed6wNKYxxXX0eQ==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.40.tgz",
+            "integrity": "sha512-NK/mM/I16inThgXmKPxoqrg+N6OCLt+e9Zsmy8TJ93/zMx4Eddd679I231YwDP2J1Z12UgkfWCLbbvauU5TLlQ==",
             "dev": true,
             "requires": {
-                "@babel/template": "7.0.0-beta.38",
-                "@babel/traverse": "7.0.0-beta.38",
-                "@babel/types": "7.0.0-beta.38"
+                "@babel/template": "7.0.0-beta.40",
+                "@babel/traverse": "7.0.0-beta.40",
+                "@babel/types": "7.0.0-beta.40"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
+            "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.3.2",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
             }
         },
         "@babel/register": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/register/-/register-7.0.0-beta.38.tgz",
-            "integrity": "sha512-szE2vMZ8FB6NkywESqDGcAtchQafaWLQgJo3xro7GIgNRmJoAX2xZijU1e5AKT4zWkRRc53aBBwfZy03aWsPgw==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.40.tgz",
+            "integrity": "sha512-/9ATJf2/YN6MyU1FvagOEh8BhYrCMZRHYgmRPX9T+w0w5ALM8hXCCzmdlxz70dxDfLrf+h4UoFhIdAb+FC8nOw==",
             "dev": true,
             "requires": {
                 "core-js": "2.5.3",
@@ -145,38 +160,38 @@
             }
         },
         "@babel/template": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/template/-/template-7.0.0-beta.38.tgz",
-            "integrity": "sha512-ygOSe1+ekKVkn5zxCH0rqv5sZtvLfC72yPQSaXLTHtYSYdAyXNqOW7q1ua1zJll9glk0UWYAnUEcehQXXc3fEA==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
+            "integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.38",
-                "@babel/types": "7.0.0-beta.38",
-                "babylon": "7.0.0-beta.38",
+                "@babel/code-frame": "7.0.0-beta.40",
+                "@babel/types": "7.0.0-beta.40",
+                "babylon": "7.0.0-beta.40",
                 "lodash": "4.17.4"
             }
         },
         "@babel/traverse": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
-            "integrity": "sha512-qbrc59aPCnMCj3uroG7QXdFMmrFLFvEfcwfVzmF2MXh2a7OhRzs73g/PNN8Xb0W/4Z1H4ZTY95CczmfDmXapnw==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
+            "integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.38",
-                "@babel/generator": "7.0.0-beta.38",
-                "@babel/helper-function-name": "7.0.0-beta.38",
-                "@babel/types": "7.0.0-beta.38",
-                "babylon": "7.0.0-beta.38",
+                "@babel/code-frame": "7.0.0-beta.40",
+                "@babel/generator": "7.0.0-beta.40",
+                "@babel/helper-function-name": "7.0.0-beta.40",
+                "@babel/types": "7.0.0-beta.40",
+                "babylon": "7.0.0-beta.40",
                 "debug": "3.1.0",
-                "globals": "11.1.0",
+                "globals": "11.3.0",
                 "invariant": "2.2.2",
                 "lodash": "4.17.4"
             }
         },
         "@babel/types": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/types/-/types-7.0.0-beta.38.tgz",
-            "integrity": "sha512-SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
+            "integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
             "dev": true,
             "requires": {
                 "esutils": "2.0.2",
@@ -186,7 +201,7 @@
         },
         "ansi-gray": {
             "version": "0.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
             "requires": {
                 "ansi-wrap": "0.1.0"
@@ -194,22 +209,22 @@
         },
         "ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "2.2.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "ansi-wrap": {
             "version": "0.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "anymatch": {
             "version": "1.3.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/anymatch/-/anymatch-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "optional": true,
@@ -220,7 +235,7 @@
         },
         "argparse": {
             "version": "1.0.9",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/argparse/-/argparse-1.0.9.tgz",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "dev": true,
             "requires": {
@@ -229,7 +244,7 @@
         },
         "arr-diff": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/arr-diff/-/arr-diff-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
@@ -238,36 +253,36 @@
         },
         "arr-flatten": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "array-differ": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-differ/-/array-differ-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-uniq": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-uniq/-/array-uniq-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
         },
         "array-unique": {
             "version": "0.2.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-unique/-/array-unique-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true
         },
         "async-each": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/async-each/-/async-each-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
             "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
             "dev": true,
             "optional": true
         },
         "babel-code-frame": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
@@ -278,7 +293,7 @@
         },
         "babel-core": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-core/-/babel-core-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
             "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
             "dev": true,
             "requires": {
@@ -305,13 +320,13 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 },
                 "debug": {
                     "version": "2.6.9",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/debug/-/debug-2.6.9.tgz",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "dev": true,
                     "requires": {
@@ -322,7 +337,7 @@
         },
         "babel-generator": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-generator/-/babel-generator-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
             "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
             "dev": true,
             "requires": {
@@ -338,7 +353,7 @@
             "dependencies": {
                 "jsesc": {
                     "version": "1.3.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/jsesc/-/jsesc-1.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
                     "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
                     "dev": true
                 }
@@ -346,7 +361,7 @@
         },
         "babel-helpers": {
             "version": "6.24.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
@@ -356,7 +371,7 @@
         },
         "babel-messages": {
             "version": "6.23.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-messages/-/babel-messages-6.23.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
@@ -365,7 +380,7 @@
         },
         "babel-plugin-macros": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-plugin-macros/-/babel-plugin-macros-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.0.0.tgz",
             "integrity": "sha512-MSsoNjn8yLe3s71m4THcOXn1ZKXVHVpKNoRKCAEUe9mrkECAazW+ON5lJnjMPAuAPllAPh/WaUqoSduMu1//ew==",
             "dev": true,
             "requires": {
@@ -374,7 +389,7 @@
         },
         "babel-plugin-preval": {
             "version": "1.6.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-plugin-preval/-/babel-plugin-preval-1.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-1.6.3.tgz",
             "integrity": "sha512-c33fXpCx7H/ESwAKuPu8wcYNh6zoS1kqTcQGW/I8ObOOIx7LgYo2SN1OfiRd3AppsDxbISJjrlVnyydEfWwT0A==",
             "dev": true,
             "requires": {
@@ -386,7 +401,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 }
@@ -394,7 +409,7 @@
         },
         "babel-register": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-register/-/babel-register-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
@@ -409,7 +424,7 @@
             "dependencies": {
                 "home-or-tmp": {
                     "version": "2.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
                     "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
                     "dev": true,
                     "requires": {
@@ -421,7 +436,7 @@
         },
         "babel-runtime": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
@@ -431,7 +446,7 @@
         },
         "babel-template": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-template/-/babel-template-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
@@ -444,7 +459,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 }
@@ -452,7 +467,7 @@
         },
         "babel-traverse": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
@@ -469,13 +484,13 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 },
                 "debug": {
                     "version": "2.6.9",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/debug/-/debug-2.6.9.tgz",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "dev": true,
                     "requires": {
@@ -484,7 +499,7 @@
                 },
                 "globals": {
                     "version": "9.18.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/globals/-/globals-9.18.0.tgz",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
                     "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
                     "dev": true
                 }
@@ -492,7 +507,7 @@
         },
         "babel-types": {
             "version": "6.26.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-types/-/babel-types-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
@@ -504,39 +519,39 @@
             "dependencies": {
                 "to-fast-properties": {
                     "version": "1.0.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                     "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
                     "dev": true
                 }
             }
         },
         "babylon": {
-            "version": "7.0.0-beta.38",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-7.0.0-beta.38.tgz",
-            "integrity": "sha512-ukc+RoVsxNjsFGTgXtCGr/RcNHQ4/OKBZQ2B6C2XBQwrbxXGWxgOMF9xgQ2WAQJQtvur3N6xakpIGMRNfGtt8Q==",
+            "version": "7.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
+            "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
             "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/balanced-match/-/balanced-match-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
         "beeper": {
             "version": "1.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/beeper/-/beeper-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
             "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
         },
         "binary-extensions": {
             "version": "1.11.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/binary-extensions/-/binary-extensions-1.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
             "dev": true,
             "optional": true
         },
         "brace-expansion": {
             "version": "1.1.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
@@ -546,7 +561,7 @@
         },
         "braces": {
             "version": "1.8.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/braces/-/braces-1.8.5.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
@@ -557,13 +572,13 @@
         },
         "browser-stdout": {
             "version": "1.3.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
         },
         "chalk": {
             "version": "1.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chalk/-/chalk-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
                 "ansi-styles": "2.2.1",
@@ -575,13 +590,14 @@
         },
         "chokidar": {
             "version": "1.7.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chokidar/-/chokidar-1.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "optional": true,
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
+                "fsevents": "1.1.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -592,17 +608,17 @@
         },
         "clone": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/clone/-/clone-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
             "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
         },
         "clone-stats": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/clone-stats/-/clone-stats-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
             "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "color-convert": {
             "version": "1.9.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-convert/-/color-convert-1.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
@@ -611,13 +627,13 @@
         },
         "color-name": {
             "version": "1.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "color-support": {
             "version": "1.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-support/-/color-support-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
         },
         "commander": {
@@ -628,36 +644,36 @@
         },
         "commondir": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commondir/-/commondir-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
         "convert-source-map": {
             "version": "1.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
             "dev": true
         },
         "core-js": {
             "version": "2.5.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/core-js/-/core-js-2.5.3.tgz",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
             "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
             "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cosmiconfig": {
             "version": "3.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
             "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
             "dev": true,
             "requires": {
@@ -669,12 +685,12 @@
         },
         "dateformat": {
             "version": "2.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/dateformat/-/dateformat-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
             "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "debug": {
             "version": "3.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/debug/-/debug-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
             "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
@@ -683,7 +699,7 @@
         },
         "detect-indent": {
             "version": "4.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/detect-indent/-/detect-indent-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
@@ -692,13 +708,13 @@
         },
         "diff": {
             "version": "3.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/diff/-/diff-3.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
             "dev": true
         },
         "duplexer2": {
             "version": "0.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/duplexer2/-/duplexer2-0.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "requires": {
                 "readable-stream": "1.1.14"
@@ -706,7 +722,7 @@
         },
         "error-ex": {
             "version": "1.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/error-ex/-/error-ex-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
@@ -715,24 +731,24 @@
         },
         "escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "esprima": {
             "version": "4.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/esprima/-/esprima-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
             "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
             "dev": true
         },
         "esutils": {
             "version": "2.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/esutils/-/esutils-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "expand-brackets": {
             "version": "0.1.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
@@ -741,7 +757,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -750,7 +766,7 @@
         },
         "extglob": {
             "version": "0.3.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/extglob/-/extglob-0.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
@@ -759,7 +775,7 @@
         },
         "fancy-log": {
             "version": "1.3.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fancy-log/-/fancy-log-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
                 "ansi-gray": "0.1.1",
@@ -769,13 +785,13 @@
         },
         "filename-regex": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/filename-regex/-/filename-regex-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
             "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
             "dev": true
         },
         "fill-range": {
             "version": "2.2.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fill-range/-/fill-range-2.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
@@ -788,18 +804,18 @@
         },
         "find-cache-dir": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
                 "commondir": "1.0.1",
-                "make-dir": "1.1.0",
+                "make-dir": "1.2.0",
                 "pkg-dir": "2.0.0"
             }
         },
         "find-up": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/find-up/-/find-up-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
@@ -808,13 +824,13 @@
         },
         "for-in": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/for-in/-/for-in-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
         "for-own": {
             "version": "0.1.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/for-own/-/for-own-0.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
@@ -823,19 +839,923 @@
         },
         "fs-readdir-recursive": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
             "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
             "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.9.2",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
         "glob": {
             "version": "7.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob/-/glob-7.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
@@ -849,7 +1769,7 @@
         },
         "glob-base": {
             "version": "0.3.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob-base/-/glob-base-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
@@ -859,7 +1779,7 @@
         },
         "glob-parent": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob-parent/-/glob-parent-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
@@ -867,14 +1787,14 @@
             }
         },
         "globals": {
-            "version": "11.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/globals/-/globals-11.1.0.tgz",
-            "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+            "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
             "dev": true
         },
         "glogg": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glogg/-/glogg-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
                 "sparkles": "1.0.0"
@@ -882,19 +1802,19 @@
         },
         "graceful-fs": {
             "version": "4.1.11",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
             "dev": true
         },
         "growl": {
             "version": "1.10.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/growl/-/growl-1.10.3.tgz",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
             "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
             "dev": true
         },
         "gulp-util": {
             "version": "3.0.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/gulp-util/-/gulp-util-3.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "requires": {
                 "array-differ": "1.0.0",
@@ -919,7 +1839,7 @@
         },
         "gulplog": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/gulplog/-/gulplog-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
                 "glogg": "1.0.1"
@@ -927,7 +1847,7 @@
         },
         "has-ansi": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-ansi/-/has-ansi-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
                 "ansi-regex": "2.1.1"
@@ -935,13 +1855,13 @@
         },
         "has-flag": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-flag/-/has-flag-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
         "has-gulplog": {
             "version": "0.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "requires": {
                 "sparkles": "1.0.0"
@@ -949,19 +1869,19 @@
         },
         "he": {
             "version": "1.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/he/-/he-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
         "home-or-tmp": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
             "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
             "dev": true
         },
         "inflight": {
             "version": "1.0.6",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
@@ -971,12 +1891,12 @@
         },
         "inherits": {
             "version": "2.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/inherits/-/inherits-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "invariant": {
             "version": "2.2.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/invariant/-/invariant-2.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
             "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
             "dev": true,
             "requires": {
@@ -985,13 +1905,13 @@
         },
         "is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
         "is-binary-path": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "optional": true,
@@ -1001,25 +1921,25 @@
         },
         "is-buffer": {
             "version": "1.1.6",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-buffer/-/is-buffer-1.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-directory": {
             "version": "0.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-directory/-/is-directory-0.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
             "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
             "dev": true
         },
         "is-dotfile": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
             "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
             "dev": true
         },
         "is-equal-shallow": {
             "version": "0.1.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
@@ -1028,19 +1948,19 @@
         },
         "is-extendable": {
             "version": "0.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-extendable/-/is-extendable-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
         "is-extglob": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-extglob/-/is-extglob-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
             "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
             "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-finite/-/is-finite-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
@@ -1049,7 +1969,7 @@
         },
         "is-glob": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-glob/-/is-glob-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
@@ -1058,7 +1978,7 @@
         },
         "is-number": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-number/-/is-number-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
@@ -1067,30 +1987,30 @@
         },
         "is-plain-obj": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
         "is-posix-bracket": {
             "version": "0.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
             "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
             "dev": true
         },
         "is-primitive": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-primitive/-/is-primitive-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
             "dev": true
         },
         "isarray": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "isobject": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isobject/-/isobject-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
             "requires": {
@@ -1099,7 +2019,7 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 }
@@ -1107,13 +2027,13 @@
         },
         "js-tokens": {
             "version": "3.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/js-tokens/-/js-tokens-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
         "js-yaml": {
             "version": "3.10.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/js-yaml/-/js-yaml-3.10.0.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
             "dev": true,
             "requires": {
@@ -1123,19 +2043,19 @@
         },
         "jsesc": {
             "version": "2.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/jsesc/-/jsesc-2.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
             "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
             "dev": true
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/json5/-/json5-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
         "kind-of": {
             "version": "3.2.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-3.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
@@ -1144,7 +2064,7 @@
         },
         "locate-path": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/locate-path/-/locate-path-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
@@ -1154,58 +2074,58 @@
         },
         "lodash": {
             "version": "4.17.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash/-/lodash-4.17.4.tgz",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
             "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
             "dev": true
         },
         "lodash._basecopy": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
             "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
         },
         "lodash._basetostring": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
             "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
         },
         "lodash._basevalues": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
             "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
         },
         "lodash._getnative": {
             "version": "3.9.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
             "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
         "lodash._isiterateecall": {
             "version": "3.0.9",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
             "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
         },
         "lodash._reescape": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
             "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
         },
         "lodash._reevaluate": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
             "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
         },
         "lodash._root": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._root/-/lodash._root-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
         "lodash.escape": {
             "version": "3.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "requires": {
                 "lodash._root": "3.0.1"
@@ -1213,17 +2133,17 @@
         },
         "lodash.isarguments": {
             "version": "3.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
             "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
         },
         "lodash.isarray": {
             "version": "3.0.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
         },
         "lodash.keys": {
             "version": "3.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "requires": {
                 "lodash._getnative": "3.9.1",
@@ -1233,12 +2153,12 @@
         },
         "lodash.restparam": {
             "version": "3.6.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
             "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
         },
         "lodash.template": {
             "version": "3.6.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.template/-/lodash.template-3.6.2.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "requires": {
                 "lodash._basecopy": "3.0.1",
@@ -1254,7 +2174,7 @@
         },
         "lodash.templatesettings": {
             "version": "3.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "requires": {
                 "lodash._reinterpolate": "3.0.0",
@@ -1263,7 +2183,7 @@
         },
         "loose-envify": {
             "version": "1.3.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/loose-envify/-/loose-envify-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
@@ -1271,9 +2191,9 @@
             }
         },
         "make-dir": {
-            "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/make-dir/-/make-dir-1.1.0.tgz",
-            "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+            "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
             "dev": true,
             "requires": {
                 "pify": "3.0.0"
@@ -1281,7 +2201,7 @@
         },
         "micromatch": {
             "version": "2.3.11",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/micromatch/-/micromatch-2.3.11.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
@@ -1302,7 +2222,7 @@
         },
         "minimatch": {
             "version": "3.0.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimatch/-/minimatch-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
@@ -1311,12 +2231,12 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -1325,7 +2245,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimist/-/minimist-0.0.8.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 }
@@ -1333,7 +2253,7 @@
         },
         "mocha": {
             "version": "5.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/mocha/-/mocha-5.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
             "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
             "dev": true,
             "requires": {
@@ -1351,7 +2271,7 @@
             "dependencies": {
                 "supports-color": {
                     "version": "4.4.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-4.4.0.tgz",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
@@ -1362,27 +2282,34 @@
         },
         "ms": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
         "multipipe": {
             "version": "0.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/multipipe/-/multipipe-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
             "requires": {
                 "duplexer2": "0.0.2"
             }
         },
+        "nan": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+            "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+            "dev": true,
+            "optional": true
+        },
         "node-modules-regexp": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
             "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
             "dev": true
         },
         "normalize-path": {
             "version": "2.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/normalize-path/-/normalize-path-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
@@ -1391,18 +2318,18 @@
         },
         "number-is-nan": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
         "object-assign": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/object-assign/-/object-assign-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
             "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "object.omit": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/object.omit/-/object.omit-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
@@ -1412,7 +2339,7 @@
         },
         "once": {
             "version": "1.4.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/once/-/once-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
@@ -1421,20 +2348,20 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
         "output-file-sync": {
-            "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/output-file-sync/-/output-file-sync-2.0.0.tgz",
-            "integrity": "sha1-XTSKGh6u0a0WhkigGi1tEweM6Yc=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
+            "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "4.1.11",
@@ -1444,7 +2371,7 @@
         },
         "p-limit": {
             "version": "1.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-limit/-/p-limit-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
@@ -1453,7 +2380,7 @@
         },
         "p-locate": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-locate/-/p-locate-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
@@ -1462,13 +2389,13 @@
         },
         "p-try": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-try/-/p-try-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
         "parse-glob": {
             "version": "3.0.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/parse-glob/-/parse-glob-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
@@ -1480,7 +2407,7 @@
         },
         "parse-json": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/parse-json/-/parse-json-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
             "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
             "dev": true,
             "requires": {
@@ -1489,31 +2416,31 @@
         },
         "path-exists": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-exists/-/path-exists-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
         "path-parse": {
             "version": "1.0.5",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-parse/-/path-parse-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
             "dev": true
         },
         "pify": {
             "version": "3.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pify/-/pify-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
         "pirates": {
             "version": "3.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pirates/-/pirates-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
             "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
             "dev": true,
             "requires": {
@@ -1522,7 +2449,7 @@
         },
         "pkg-dir": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
@@ -1531,24 +2458,24 @@
         },
         "preserve": {
             "version": "0.2.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/preserve/-/preserve-0.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
             "dev": true
         },
         "private": {
             "version": "0.1.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/private/-/private-0.1.8.tgz",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
             "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
         "process-nextick-args": {
             "version": "1.0.7",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "randomatic": {
             "version": "1.1.7",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/randomatic/-/randomatic-1.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
@@ -1558,7 +2485,7 @@
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
@@ -1567,7 +2494,7 @@
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
@@ -1578,7 +2505,7 @@
                 },
                 "kind-of": {
                     "version": "4.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
@@ -1589,7 +2516,7 @@
         },
         "readable-stream": {
             "version": "1.1.14",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-1.1.14.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
             "requires": {
                 "core-util-is": "1.0.2",
@@ -1600,35 +2527,42 @@
         },
         "readdirp": {
             "version": "2.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readdirp/-/readdirp-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "optional": true,
             "requires": {
                 "graceful-fs": "4.1.11",
                 "minimatch": "3.0.4",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.5",
                 "set-immediate-shim": "1.0.1"
             },
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true,
                     "optional": true
                 },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true,
+                    "optional": true
+                },
                 "readable-stream": {
-                    "version": "2.3.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-2.3.3.tgz",
-                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
+                        "process-nextick-args": "2.0.0",
                         "safe-buffer": "5.1.1",
                         "string_decoder": "1.0.3",
                         "util-deprecate": "1.0.2"
@@ -1636,7 +2570,7 @@
                 },
                 "string_decoder": {
                     "version": "1.0.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "optional": true,
@@ -1648,13 +2582,13 @@
         },
         "regenerator-runtime": {
             "version": "0.11.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
             "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
             "dev": true
         },
         "regex-cache": {
             "version": "0.4.4",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/regex-cache/-/regex-cache-0.4.4.tgz",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
@@ -1663,25 +2597,25 @@
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
         },
         "repeat-element": {
             "version": "1.1.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeat-element/-/repeat-element-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
             "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
             "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeat-string/-/repeat-string-1.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
         "repeating": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeating/-/repeating-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
@@ -1690,18 +2624,18 @@
         },
         "replace-ext": {
             "version": "0.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/replace-ext/-/replace-ext-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "require-from-string": {
             "version": "2.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/require-from-string/-/require-from-string-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
             "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
             "dev": true
         },
         "resolve": {
             "version": "1.5.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/resolve/-/resolve-1.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
@@ -1710,7 +2644,7 @@
         },
         "rimraf": {
             "version": "2.6.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/rimraf/-/rimraf-2.6.2.tgz",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
@@ -1719,31 +2653,31 @@
         },
         "safe-buffer": {
             "version": "5.1.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "set-immediate-shim": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "dev": true,
             "optional": true
         },
         "slash": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/slash/-/slash-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
             "dev": true
         },
         "source-map": {
             "version": "0.5.7",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map/-/source-map-0.5.7.tgz",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
         "source-map-support": {
             "version": "0.4.18",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map-support/-/source-map-support-0.4.18.tgz",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
@@ -1752,23 +2686,23 @@
         },
         "sparkles": {
             "version": "1.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/sparkles/-/sparkles-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
             "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "string_decoder": {
             "version": "0.10.31",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-0.10.31.tgz",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "2.1.1"
@@ -1776,12 +2710,12 @@
         },
         "supports-color": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "through2": {
             "version": "2.0.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/through2/-/through2-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
                 "readable-stream": "2.3.3",
@@ -1790,12 +2724,12 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "readable-stream": {
                     "version": "2.3.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "requires": {
                         "core-util-is": "1.0.2",
@@ -1809,7 +2743,7 @@
                 },
                 "string_decoder": {
                     "version": "1.0.3",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "requires": {
                         "safe-buffer": "5.1.1"
@@ -1819,24 +2753,24 @@
         },
         "time-stamp": {
             "version": "1.1.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/time-stamp/-/time-stamp-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
         },
         "to-fast-properties": {
             "version": "2.0.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/trim-right/-/trim-right-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "uglify-js": {
             "version": "3.3.8",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/uglify-js/-/uglify-js-3.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.8.tgz",
             "integrity": "sha512-X0jAGtpSZRtd4RhbVNuGHyjZNa/h2MrVkKrR3Ew5iL2MJw6d7FmBke+fhVCALWySv1ygHnjjROG1KI1FAPvddw==",
             "dev": true,
             "requires": {
@@ -1852,7 +2786,7 @@
                 },
                 "source-map": {
                     "version": "0.6.1",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map/-/source-map-0.6.1.tgz",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
@@ -1860,12 +2794,12 @@
         },
         "util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vinyl": {
             "version": "0.5.3",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/vinyl/-/vinyl-0.5.3.tgz",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "requires": {
                 "clone": "1.0.3",
@@ -1875,13 +2809,13 @@
         },
         "wrappy": {
             "version": "1.0.2",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
         "xtend": {
             "version": "4.0.1",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/xtend/-/xtend-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gulp-css2js",
-    "version": "1.1.1",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/cli": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/cli/-/cli-7.0.0-beta.38.tgz",
             "integrity": "sha512-RF2RQh9gvxeXtwrFzgf4PKCsmCPsa/tHaL0TQ3eWRoyno91GsoYnAhh/SnvPrlvXV+9Uosw+zwOgwnVyRvPDYQ==",
             "dev": true,
             "requires": {
@@ -15,63 +15,57 @@
                 "convert-source-map": "1.5.1",
                 "fs-readdir-recursive": "1.1.0",
                 "glob": "7.1.2",
-                "lodash": "4.17.5",
-                "output-file-sync": "2.0.1",
+                "lodash": "4.17.4",
+                "output-file-sync": "2.0.0",
                 "slash": "1.0.0",
                 "source-map": "0.5.7"
             }
         },
         "@babel/code-frame": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
             "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.3.0",
                 "esutils": "2.0.2",
                 "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "version": "3.2.0",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
                         "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
+                        "ansi-styles": "3.2.0",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "4.5.0"
                     }
                 },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "4.5.0",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "2.0.0"
                     }
                 }
             }
         },
         "@babel/core": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/core/-/core-7.0.0-beta.38.tgz",
             "integrity": "sha512-xIDdSeSElby0p6QMowawWrU9VulpMk1yq6RaKYjaZBRT7s40kztTsDw8+VUVuQmdRbqLh8DpLWs15oaUWphsPg==",
             "dev": true,
             "requires": {
@@ -85,39 +79,28 @@
                 "convert-source-map": "1.5.1",
                 "debug": "3.1.0",
                 "json5": "0.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "micromatch": "2.3.11",
                 "resolve": "1.5.0",
                 "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
             }
         },
         "@babel/generator": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/generator/-/generator-7.0.0-beta.38.tgz",
             "integrity": "sha512-aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==",
             "dev": true,
             "requires": {
                 "@babel/types": "7.0.0-beta.38",
                 "jsesc": "2.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             }
         },
         "@babel/helper-function-name": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
             "integrity": "sha512-vLOtqh2PMbvOXL/+DlwH6A2/y+81l518Z0x7232T4E8HiMBQbkv3rNg4GmjJ5M6GcZzj7UKTBrVt8AXcH4OTdA==",
             "dev": true,
             "requires": {
@@ -128,7 +111,7 @@
         },
         "@babel/helper-get-function-arity": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
             "integrity": "sha512-ty3muWaxHPcvdwihBWqGBD+s+hjt4Tua3In43eA4BvLMKWtTYsJBGdLoWQUY4TXhVgDe7wPzqxIv2AUbnIh/vQ==",
             "dev": true,
             "requires": {
@@ -137,7 +120,7 @@
         },
         "@babel/helpers": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
             "integrity": "sha512-DNdEZABrx2oNSpqijJHjxR/V36hMIQgFkdgv/iQsJ7xhXhObIrH1FMXsd3jbnlgblTc/7/hYed6wNKYxxXX0eQ==",
             "dev": true,
             "requires": {
@@ -148,14 +131,14 @@
         },
         "@babel/register": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/register/-/register-7.0.0-beta.38.tgz",
             "integrity": "sha512-szE2vMZ8FB6NkywESqDGcAtchQafaWLQgJo3xro7GIgNRmJoAX2xZijU1e5AKT4zWkRRc53aBBwfZy03aWsPgw==",
             "dev": true,
             "requires": {
                 "core-js": "2.5.3",
                 "find-cache-dir": "1.0.0",
                 "home-or-tmp": "3.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
                 "pirates": "3.0.2",
                 "source-map-support": "0.4.18"
@@ -163,19 +146,19 @@
         },
         "@babel/template": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/template/-/template-7.0.0-beta.38.tgz",
             "integrity": "sha512-ygOSe1+ekKVkn5zxCH0rqv5sZtvLfC72yPQSaXLTHtYSYdAyXNqOW7q1ua1zJll9glk0UWYAnUEcehQXXc3fEA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.0.0-beta.38",
                 "@babel/types": "7.0.0-beta.38",
                 "babylon": "7.0.0-beta.38",
-                "lodash": "4.17.5"
+                "lodash": "4.17.4"
             }
         },
         "@babel/traverse": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
             "integrity": "sha512-qbrc59aPCnMCj3uroG7QXdFMmrFLFvEfcwfVzmF2MXh2a7OhRzs73g/PNN8Xb0W/4Z1H4ZTY95CczmfDmXapnw==",
             "dev": true,
             "requires": {
@@ -185,36 +168,25 @@
                 "@babel/types": "7.0.0-beta.38",
                 "babylon": "7.0.0-beta.38",
                 "debug": "3.1.0",
-                "globals": "11.3.0",
-                "invariant": "2.2.3",
-                "lodash": "4.17.5"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
+                "globals": "11.1.0",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4"
             }
         },
         "@babel/types": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/@babel/types/-/types-7.0.0-beta.38.tgz",
             "integrity": "sha512-SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==",
             "dev": true,
             "requires": {
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "to-fast-properties": "2.0.0"
             }
         },
         "ansi-gray": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
             "requires": {
                 "ansi-wrap": "0.1.0"
@@ -222,22 +194,22 @@
         },
         "ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "ansi-wrap": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "anymatch": {
             "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "optional": true,
@@ -247,9 +219,9 @@
             }
         },
         "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "version": "1.0.9",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "dev": true,
             "requires": {
                 "sprintf-js": "1.0.3"
@@ -257,7 +229,7 @@
         },
         "arr-diff": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
@@ -266,36 +238,36 @@
         },
         "arr-flatten": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "array-differ": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-uniq": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
         },
         "array-unique": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true
         },
         "async-each": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/async-each/-/async-each-1.0.1.tgz",
             "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
             "dev": true,
             "optional": true
         },
         "babel-code-frame": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
@@ -306,12 +278,12 @@
         },
         "babel-core": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-core/-/babel-core-6.26.0.tgz",
             "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
             "dev": true,
             "requires": {
                 "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
+                "babel-generator": "6.26.0",
                 "babel-helpers": "6.24.1",
                 "babel-messages": "6.23.0",
                 "babel-register": "6.26.0",
@@ -323,7 +295,7 @@
                 "convert-source-map": "1.5.1",
                 "debug": "2.6.9",
                 "json5": "0.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "minimatch": "3.0.4",
                 "path-is-absolute": "1.0.1",
                 "private": "0.1.8",
@@ -333,16 +305,25 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 }
             }
         },
         "babel-generator": {
-            "version": "6.26.1",
-            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "version": "6.26.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-generator/-/babel-generator-6.26.0.tgz",
+            "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
             "dev": true,
             "requires": {
                 "babel-messages": "6.23.0",
@@ -350,14 +331,14 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             },
             "dependencies": {
                 "jsesc": {
                     "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/jsesc/-/jsesc-1.3.0.tgz",
                     "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
                     "dev": true
                 }
@@ -365,7 +346,7 @@
         },
         "babel-helpers": {
             "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
@@ -375,7 +356,7 @@
         },
         "babel-messages": {
             "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
@@ -383,21 +364,21 @@
             }
         },
         "babel-plugin-macros": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.2.0.tgz",
-            "integrity": "sha512-HGdenPU9+WGhg++P65O+6aIdmXx99p58K7VtAtizC3eUHbO4FXfyfK9SCJubylcyKziEB3nMAUDFHeyDUj38eA==",
+            "version": "2.0.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-plugin-macros/-/babel-plugin-macros-2.0.0.tgz",
+            "integrity": "sha512-MSsoNjn8yLe3s71m4THcOXn1ZKXVHVpKNoRKCAEUe9mrkECAazW+ON5lJnjMPAuAPllAPh/WaUqoSduMu1//ew==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "4.0.0"
+                "cosmiconfig": "3.1.0"
             }
         },
         "babel-plugin-preval": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-1.6.4.tgz",
-            "integrity": "sha512-XuNaiZ76CsdWialH2co05YRra9NlsyriTUbJ+56MAcWN9v33drTm5ovBRFuEKVj1dNRhEdBjeEyYtkkaRE8drw==",
+            "version": "1.6.3",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-plugin-preval/-/babel-plugin-preval-1.6.3.tgz",
+            "integrity": "sha512-c33fXpCx7H/ESwAKuPu8wcYNh6zoS1kqTcQGW/I8ObOOIx7LgYo2SN1OfiRd3AppsDxbISJjrlVnyydEfWwT0A==",
             "dev": true,
             "requires": {
-                "babel-plugin-macros": "2.2.0",
+                "babel-plugin-macros": "2.0.0",
                 "babel-register": "6.26.0",
                 "babylon": "6.18.0",
                 "require-from-string": "2.0.1"
@@ -405,7 +386,7 @@
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 }
@@ -413,7 +394,7 @@
         },
         "babel-register": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
@@ -421,14 +402,14 @@
                 "babel-runtime": "6.26.0",
                 "core-js": "2.5.3",
                 "home-or-tmp": "2.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "mkdirp": "0.5.1",
                 "source-map-support": "0.4.18"
             },
             "dependencies": {
                 "home-or-tmp": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
                     "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
                     "dev": true,
                     "requires": {
@@ -440,7 +421,7 @@
         },
         "babel-runtime": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
@@ -450,7 +431,7 @@
         },
         "babel-template": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-template/-/babel-template-6.26.0.tgz",
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
@@ -458,12 +439,12 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.4"
             },
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 }
@@ -471,7 +452,7 @@
         },
         "babel-traverse": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-traverse/-/babel-traverse-6.26.0.tgz",
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
@@ -482,19 +463,28 @@
                 "babylon": "6.18.0",
                 "debug": "2.6.9",
                 "globals": "9.18.0",
-                "invariant": "2.2.3",
-                "lodash": "4.17.5"
+                "invariant": "2.2.2",
+                "lodash": "4.17.4"
             },
             "dependencies": {
                 "babylon": {
                     "version": "6.18.0",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
                 },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
                 "globals": {
                     "version": "9.18.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/globals/-/globals-9.18.0.tgz",
                     "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
                     "dev": true
                 }
@@ -502,19 +492,19 @@
         },
         "babel-types": {
             "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babel-types/-/babel-types-6.26.0.tgz",
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.4",
                 "to-fast-properties": "1.0.3"
             },
             "dependencies": {
                 "to-fast-properties": {
                     "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                     "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
                     "dev": true
                 }
@@ -522,31 +512,31 @@
         },
         "babylon": {
             "version": "7.0.0-beta.38",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.38.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/babylon/-/babylon-7.0.0-beta.38.tgz",
             "integrity": "sha512-ukc+RoVsxNjsFGTgXtCGr/RcNHQ4/OKBZQ2B6C2XBQwrbxXGWxgOMF9xgQ2WAQJQtvur3N6xakpIGMRNfGtt8Q==",
             "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
         "beeper": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/beeper/-/beeper-1.1.1.tgz",
             "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
         },
         "binary-extensions": {
             "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
             "dev": true,
             "optional": true
         },
         "brace-expansion": {
             "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
@@ -556,7 +546,7 @@
         },
         "braces": {
             "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
@@ -566,14 +556,14 @@
             }
         },
         "browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "version": "1.3.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
         },
         "chalk": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
                 "ansi-styles": "2.2.1",
@@ -585,14 +575,13 @@
         },
         "chokidar": {
             "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "optional": true,
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
-                "fsevents": "1.1.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -603,17 +592,17 @@
         },
         "clone": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/clone/-/clone-1.0.3.tgz",
             "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
         },
         "clone-stats": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/clone-stats/-/clone-stats-0.0.1.tgz",
             "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "color-convert": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
@@ -622,71 +611,71 @@
         },
         "color-name": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "color-support": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
         },
         "commander": {
             "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commander/-/commander-2.11.0.tgz",
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
             "dev": true
         },
         "commondir": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
         "convert-source-map": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/convert-source-map/-/convert-source-map-1.5.1.tgz",
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
             "dev": true
         },
         "core-js": {
             "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/core-js/-/core-js-2.5.3.tgz",
             "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
             "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cosmiconfig": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-            "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+            "version": "3.1.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+            "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
             "dev": true,
             "requires": {
                 "is-directory": "0.3.1",
-                "js-yaml": "3.11.0",
-                "parse-json": "4.0.0",
+                "js-yaml": "3.10.0",
+                "parse-json": "3.0.0",
                 "require-from-string": "2.0.1"
             }
         },
         "dateformat": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/dateformat/-/dateformat-2.2.0.tgz",
             "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "3.1.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -694,7 +683,7 @@
         },
         "detect-indent": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
@@ -703,13 +692,13 @@
         },
         "diff": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/diff/-/diff-3.3.1.tgz",
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
             "dev": true
         },
         "duplexer2": {
             "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "requires": {
                 "readable-stream": "1.1.14"
@@ -717,7 +706,7 @@
         },
         "error-ex": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/error-ex/-/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
@@ -726,24 +715,24 @@
         },
         "escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "esprima": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/esprima/-/esprima-4.0.0.tgz",
             "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
             "dev": true
         },
         "esutils": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "expand-brackets": {
             "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
@@ -752,7 +741,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -761,7 +750,7 @@
         },
         "extglob": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
@@ -770,7 +759,7 @@
         },
         "fancy-log": {
             "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
                 "ansi-gray": "0.1.1",
@@ -780,13 +769,13 @@
         },
         "filename-regex": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/filename-regex/-/filename-regex-2.0.1.tgz",
             "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
             "dev": true
         },
         "fill-range": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
@@ -799,18 +788,18 @@
         },
         "find-cache-dir": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
                 "commondir": "1.0.1",
-                "make-dir": "1.2.0",
+                "make-dir": "1.1.0",
                 "pkg-dir": "2.0.0"
             }
         },
         "find-up": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
@@ -819,13 +808,13 @@
         },
         "for-in": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
         "for-own": {
             "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
@@ -834,923 +823,19 @@
         },
         "fs-readdir-recursive": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
             "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
             "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "fsevents": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "nan": "2.9.2",
-                "node-pre-gyp": "0.6.39"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ajv": {
-                    "version": "4.11.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "aproba": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
-                    }
-                },
-                "asn1": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aws4": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "balanced-match": {
-                    "version": "0.4.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "tweetnacl": "0.14.5"
-                    }
-                },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.7",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "buffer-shims": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "co": {
-                    "version": "4.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "combined-stream": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "delayed-stream": "1.0.0"
-                    }
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "debug": {
-                    "version": "2.6.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.4.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ecc-jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "extend": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "extsprintf": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
-                    }
-                },
-                "fstream-ignore": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                    }
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
-                    }
-                },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "bundled": true,
-                    "dev": true
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "hawk": {
-                    "version": "3.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "hoek": {
-                    "version": "2.16.3",
-                    "bundled": true,
-                    "dev": true
-                },
-                "http-signature": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "dev": true
-                },
-                "ini": {
-                    "version": "1.3.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "1.0.1"
-                    }
-                },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jodid25519": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jsprim": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "mime-db": {
-                    "version": "1.27.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.1.15",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.27.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "node-pre-gyp": {
-                    "version": "0.6.39",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "1.0.2",
-                        "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "oauth-sign": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "wrappy": "1.0.2"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "dev": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "qs": {
-                    "version": "6.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.2.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "request": {
-                    "version": "2.81.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "glob": "7.1.2"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "semver": {
-                    "version": "5.3.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "sntp": {
-                    "version": "1.0.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "sshpk": {
-                    "version": "1.13.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "stringstream": {
-                    "version": "0.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
-                    }
-                },
-                "tar-pack": {
-                    "version": "3.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
-                    }
-                },
-                "tough-cookie": {
-                    "version": "2.3.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "punycode": "1.4.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "uid-number": {
-                    "version": "0.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "uuid": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "verror": {
-                    "version": "1.3.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "extsprintf": "1.0.2"
-                    }
-                },
-                "wide-align": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "1.0.2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                }
-            }
-        },
         "glob": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
@@ -1764,7 +849,7 @@
         },
         "glob-base": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
@@ -1774,7 +859,7 @@
         },
         "glob-parent": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
@@ -1782,14 +867,14 @@
             }
         },
         "globals": {
-            "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-            "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+            "version": "11.1.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/globals/-/globals-11.1.0.tgz",
+            "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
             "dev": true
         },
         "glogg": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
                 "sparkles": "1.0.0"
@@ -1797,19 +882,19 @@
         },
         "graceful-fs": {
             "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
             "dev": true
         },
         "growl": {
             "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/growl/-/growl-1.10.3.tgz",
             "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
             "dev": true
         },
         "gulp-util": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "requires": {
                 "array-differ": "1.0.0",
@@ -1834,7 +919,7 @@
         },
         "gulplog": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
                 "glogg": "1.0.1"
@@ -1842,7 +927,7 @@
         },
         "has-ansi": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
                 "ansi-regex": "2.1.1"
@@ -1850,13 +935,13 @@
         },
         "has-flag": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
         "has-gulplog": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "requires": {
                 "sparkles": "1.0.0"
@@ -1864,19 +949,19 @@
         },
         "he": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
         "home-or-tmp": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
             "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
             "dev": true
         },
         "inflight": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
@@ -1886,13 +971,13 @@
         },
         "inherits": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "invariant": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-            "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+            "version": "2.2.2",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/invariant/-/invariant-2.2.2.tgz",
+            "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
             "dev": true,
             "requires": {
                 "loose-envify": "1.3.1"
@@ -1900,13 +985,13 @@
         },
         "is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
         "is-binary-path": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "optional": true,
@@ -1916,25 +1001,25 @@
         },
         "is-buffer": {
             "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-directory": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-directory/-/is-directory-0.3.1.tgz",
             "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
             "dev": true
         },
         "is-dotfile": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-dotfile/-/is-dotfile-1.0.3.tgz",
             "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
             "dev": true
         },
         "is-equal-shallow": {
             "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
@@ -1943,19 +1028,19 @@
         },
         "is-extendable": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
         "is-extglob": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-extglob/-/is-extglob-1.0.0.tgz",
             "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
             "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
@@ -1964,7 +1049,7 @@
         },
         "is-glob": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
@@ -1973,7 +1058,7 @@
         },
         "is-number": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
@@ -1982,30 +1067,30 @@
         },
         "is-plain-obj": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
         "is-posix-bracket": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
             "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
             "dev": true
         },
         "is-primitive": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
             "dev": true
         },
         "isarray": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "isobject": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
             "requires": {
@@ -2014,7 +1099,7 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 }
@@ -2022,41 +1107,35 @@
         },
         "js-tokens": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
         "js-yaml": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "version": "3.10.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/js-yaml/-/js-yaml-3.10.0.tgz",
+            "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
+                "argparse": "1.0.9",
                 "esprima": "4.0.0"
             }
         },
         "jsesc": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/jsesc/-/jsesc-2.5.1.tgz",
             "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-            "dev": true
-        },
-        "json-parse-better-errors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-            "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
             "dev": true
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
         "kind-of": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
@@ -2065,7 +1144,7 @@
         },
         "locate-path": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
@@ -2074,59 +1153,59 @@
             }
         },
         "lodash": {
-            "version": "4.17.5",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+            "version": "4.17.4",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
             "dev": true
         },
         "lodash._basecopy": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
             "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
         },
         "lodash._basetostring": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
             "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
         },
         "lodash._basevalues": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
             "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
         },
         "lodash._getnative": {
             "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
             "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
         "lodash._isiterateecall": {
             "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
             "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
         },
         "lodash._reescape": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
             "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
         },
         "lodash._reevaluate": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
             "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
         },
         "lodash._root": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash._root/-/lodash._root-3.0.1.tgz",
             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
         "lodash.escape": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "requires": {
                 "lodash._root": "3.0.1"
@@ -2134,17 +1213,17 @@
         },
         "lodash.isarguments": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
             "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
         },
         "lodash.isarray": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
         },
         "lodash.keys": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "requires": {
                 "lodash._getnative": "3.9.1",
@@ -2154,12 +1233,12 @@
         },
         "lodash.restparam": {
             "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
             "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
         },
         "lodash.template": {
             "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "requires": {
                 "lodash._basecopy": "3.0.1",
@@ -2175,7 +1254,7 @@
         },
         "lodash.templatesettings": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "requires": {
                 "lodash._reinterpolate": "3.0.0",
@@ -2184,7 +1263,7 @@
         },
         "loose-envify": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
@@ -2192,9 +1271,9 @@
             }
         },
         "make-dir": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-            "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+            "version": "1.1.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/make-dir/-/make-dir-1.1.0.tgz",
+            "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
             "dev": true,
             "requires": {
                 "pify": "3.0.0"
@@ -2202,7 +1281,7 @@
         },
         "micromatch": {
             "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
@@ -2223,7 +1302,7 @@
         },
         "minimatch": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
@@ -2232,12 +1311,12 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -2246,19 +1325,19 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 }
             }
         },
         "mocha": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.2.tgz",
-            "integrity": "sha512-nmlYKMRpJZLxgzk0bRhcvlpjSisbi0x1JiRl7kctadOMPmecUie7WwCZmcyth+PzX5txKbpcMIvDZCAlx9ISxg==",
+            "version": "5.0.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/mocha/-/mocha-5.0.0.tgz",
+            "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
             "dev": true,
             "requires": {
-                "browser-stdout": "1.3.1",
+                "browser-stdout": "1.3.0",
                 "commander": "2.11.0",
                 "debug": "3.1.0",
                 "diff": "3.3.1",
@@ -2270,18 +1349,9 @@
                 "supports-color": "4.4.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
                 "supports-color": {
                     "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
@@ -2292,34 +1362,27 @@
         },
         "ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
         "multipipe": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/multipipe/-/multipipe-0.1.2.tgz",
             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
             "requires": {
                 "duplexer2": "0.0.2"
             }
         },
-        "nan": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-            "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
-            "dev": true,
-            "optional": true
-        },
         "node-modules-regexp": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
             "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
             "dev": true
         },
         "normalize-path": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
@@ -2328,18 +1391,18 @@
         },
         "number-is-nan": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
         "object-assign": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/object-assign/-/object-assign-3.0.0.tgz",
             "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "object.omit": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
@@ -2349,7 +1412,7 @@
         },
         "once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
@@ -2358,20 +1421,20 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
         "output-file-sync": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
-            "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
+            "version": "2.0.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/output-file-sync/-/output-file-sync-2.0.0.tgz",
+            "integrity": "sha1-XTSKGh6u0a0WhkigGi1tEweM6Yc=",
             "dev": true,
             "requires": {
                 "graceful-fs": "4.1.11",
@@ -2381,7 +1444,7 @@
         },
         "p-limit": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-limit/-/p-limit-1.2.0.tgz",
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
@@ -2390,7 +1453,7 @@
         },
         "p-locate": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
@@ -2399,13 +1462,13 @@
         },
         "p-try": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
         "parse-glob": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
@@ -2416,42 +1479,41 @@
             }
         },
         "parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "version": "3.0.0",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/parse-json/-/parse-json-3.0.0.tgz",
+            "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1",
-                "json-parse-better-errors": "1.0.1"
+                "error-ex": "1.3.1"
             }
         },
         "path-exists": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
         "path-parse": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/path-parse/-/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
             "dev": true
         },
         "pify": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
         "pirates": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pirates/-/pirates-3.0.2.tgz",
             "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
             "dev": true,
             "requires": {
@@ -2460,7 +1522,7 @@
         },
         "pkg-dir": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
@@ -2469,24 +1531,24 @@
         },
         "preserve": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/preserve/-/preserve-0.2.0.tgz",
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
             "dev": true
         },
         "private": {
             "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/private/-/private-0.1.8.tgz",
             "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
         "process-nextick-args": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "randomatic": {
             "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
@@ -2496,7 +1558,7 @@
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
@@ -2505,7 +1567,7 @@
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
@@ -2516,7 +1578,7 @@
                 },
                 "kind-of": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
@@ -2527,7 +1589,7 @@
         },
         "readable-stream": {
             "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
             "requires": {
                 "core-util-is": "1.0.2",
@@ -2538,42 +1600,35 @@
         },
         "readdirp": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "optional": true,
             "requires": {
                 "graceful-fs": "4.1.11",
                 "minimatch": "3.0.4",
-                "readable-stream": "2.3.5",
+                "readable-stream": "2.3.3",
                 "set-immediate-shim": "1.0.1"
             },
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true,
                     "optional": true
                 },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true,
-                    "optional": true
-                },
                 "readable-stream": {
-                    "version": "2.3.5",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "version": "2.3.3",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
+                        "process-nextick-args": "1.0.7",
                         "safe-buffer": "5.1.1",
                         "string_decoder": "1.0.3",
                         "util-deprecate": "1.0.2"
@@ -2581,7 +1636,7 @@
                 },
                 "string_decoder": {
                     "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "optional": true,
@@ -2593,13 +1648,13 @@
         },
         "regenerator-runtime": {
             "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
             "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
             "dev": true
         },
         "regex-cache": {
             "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
@@ -2608,25 +1663,25 @@
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
         },
         "repeat-element": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeat-element/-/repeat-element-1.1.2.tgz",
             "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
             "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
         "repeating": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
@@ -2635,18 +1690,18 @@
         },
         "replace-ext": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "require-from-string": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/require-from-string/-/require-from-string-2.0.1.tgz",
             "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
             "dev": true
         },
         "resolve": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/resolve/-/resolve-1.5.0.tgz",
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
@@ -2655,7 +1710,7 @@
         },
         "rimraf": {
             "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
@@ -2664,31 +1719,31 @@
         },
         "safe-buffer": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "set-immediate-shim": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "dev": true,
             "optional": true
         },
         "slash": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/slash/-/slash-1.0.0.tgz",
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
             "dev": true
         },
         "source-map": {
             "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
         "source-map-support": {
             "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map-support/-/source-map-support-0.4.18.tgz",
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
@@ -2697,23 +1752,23 @@
         },
         "sparkles": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/sparkles/-/sparkles-1.0.0.tgz",
             "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "string_decoder": {
             "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "2.1.1"
@@ -2721,12 +1776,12 @@
         },
         "supports-color": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "through2": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
                 "readable-stream": "2.3.3",
@@ -2735,12 +1790,12 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "readable-stream": {
                     "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/readable-stream/-/readable-stream-2.3.3.tgz",
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "requires": {
                         "core-util-is": "1.0.2",
@@ -2754,7 +1809,7 @@
                 },
                 "string_decoder": {
                     "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "requires": {
                         "safe-buffer": "5.1.1"
@@ -2764,40 +1819,40 @@
         },
         "time-stamp": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
         },
         "to-fast-properties": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.3.13",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.13.tgz",
-            "integrity": "sha512-7rdn/bDOG1ElSTPdh7AI5TCjLv63ZD4k8BBadN3ssIkhlaQL2c0yRxmXCyOYhZK0wZTgGgUSnYQ4CGu+Jos5cA==",
+            "version": "3.3.8",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/uglify-js/-/uglify-js-3.3.8.tgz",
+            "integrity": "sha512-X0jAGtpSZRtd4RhbVNuGHyjZNa/h2MrVkKrR3Ew5iL2MJw6d7FmBke+fhVCALWySv1ygHnjjROG1KI1FAPvddw==",
             "dev": true,
             "requires": {
-                "commander": "2.14.1",
+                "commander": "2.13.0",
                 "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.14.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-                    "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+                    "version": "2.13.0",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commander/-/commander-2.13.0.tgz",
+                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
                     "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
@@ -2805,12 +1860,12 @@
         },
         "util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vinyl": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/vinyl/-/vinyl-0.5.3.tgz",
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "requires": {
                 "clone": "1.0.3",
@@ -2820,13 +1875,13 @@
         },
         "wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
         "xtend": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@babel/cli": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.40.tgz",
-            "integrity": "sha512-7f2pWUlklOYn5USkVPlDw1yX71WsgP8EG7CTn17j4ydtGnYtD+nptTMM4J3EaRgILOgfesVkSOV+lIOnUVOAlg==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.38.tgz",
+            "integrity": "sha512-RF2RQh9gvxeXtwrFzgf4PKCsmCPsa/tHaL0TQ3eWRoyno91GsoYnAhh/SnvPrlvXV+9Uosw+zwOgwnVyRvPDYQ==",
             "dev": true,
             "requires": {
                 "chokidar": "1.7.0",
@@ -15,91 +15,16 @@
                 "convert-source-map": "1.5.1",
                 "fs-readdir-recursive": "1.1.0",
                 "glob": "7.1.2",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "output-file-sync": "2.0.1",
                 "slash": "1.0.0",
                 "source-map": "0.5.7"
             }
         },
         "@babel/code-frame": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
-            "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
-            "dev": true,
-            "requires": {
-                "@babel/highlight": "7.0.0-beta.40"
-            }
-        },
-        "@babel/core": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.40.tgz",
-            "integrity": "sha512-jJMjn/EMg89xDGv7uq4BoFg+fHEchSeqNc9YUMnGuAi/FWKBkSsDbhh2y5euw4qaGOFD2jw1le0rvCu5gPUc6Q==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "7.0.0-beta.40",
-                "@babel/generator": "7.0.0-beta.40",
-                "@babel/helpers": "7.0.0-beta.40",
-                "@babel/template": "7.0.0-beta.40",
-                "@babel/traverse": "7.0.0-beta.40",
-                "@babel/types": "7.0.0-beta.40",
-                "babylon": "7.0.0-beta.40",
-                "convert-source-map": "1.5.1",
-                "debug": "3.1.0",
-                "json5": "0.5.1",
-                "lodash": "4.17.4",
-                "micromatch": "2.3.11",
-                "resolve": "1.5.0",
-                "source-map": "0.5.7"
-            }
-        },
-        "@babel/generator": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
-            "integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "7.0.0-beta.40",
-                "jsesc": "2.5.1",
-                "lodash": "4.17.4",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
-            }
-        },
-        "@babel/helper-function-name": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
-            "integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.40",
-                "@babel/template": "7.0.0-beta.40",
-                "@babel/types": "7.0.0-beta.40"
-            }
-        },
-        "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
-            "integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "7.0.0-beta.40"
-            }
-        },
-        "@babel/helpers": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.40.tgz",
-            "integrity": "sha512-NK/mM/I16inThgXmKPxoqrg+N6OCLt+e9Zsmy8TJ93/zMx4Eddd679I231YwDP2J1Z12UgkfWCLbbvauU5TLlQ==",
-            "dev": true,
-            "requires": {
-                "@babel/template": "7.0.0-beta.40",
-                "@babel/traverse": "7.0.0-beta.40",
-                "@babel/types": "7.0.0-beta.40"
-            }
-        },
-        "@babel/highlight": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
-            "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
+            "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
             "dev": true,
             "requires": {
                 "chalk": "2.3.2",
@@ -144,58 +69,146 @@
                 }
             }
         },
+        "@babel/core": {
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.38.tgz",
+            "integrity": "sha512-xIDdSeSElby0p6QMowawWrU9VulpMk1yq6RaKYjaZBRT7s40kztTsDw8+VUVuQmdRbqLh8DpLWs15oaUWphsPg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.38",
+                "@babel/generator": "7.0.0-beta.38",
+                "@babel/helpers": "7.0.0-beta.38",
+                "@babel/template": "7.0.0-beta.38",
+                "@babel/traverse": "7.0.0-beta.38",
+                "@babel/types": "7.0.0-beta.38",
+                "babylon": "7.0.0-beta.38",
+                "convert-source-map": "1.5.1",
+                "debug": "3.1.0",
+                "json5": "0.5.1",
+                "lodash": "4.17.5",
+                "micromatch": "2.3.11",
+                "resolve": "1.5.0",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.38.tgz",
+            "integrity": "sha512-aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.0.0-beta.38",
+                "jsesc": "2.5.1",
+                "lodash": "4.17.5",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.38.tgz",
+            "integrity": "sha512-vLOtqh2PMbvOXL/+DlwH6A2/y+81l518Z0x7232T4E8HiMBQbkv3rNg4GmjJ5M6GcZzj7UKTBrVt8AXcH4OTdA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "7.0.0-beta.38",
+                "@babel/template": "7.0.0-beta.38",
+                "@babel/types": "7.0.0-beta.38"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.38.tgz",
+            "integrity": "sha512-ty3muWaxHPcvdwihBWqGBD+s+hjt4Tua3In43eA4BvLMKWtTYsJBGdLoWQUY4TXhVgDe7wPzqxIv2AUbnIh/vQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.0.0-beta.38"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.38.tgz",
+            "integrity": "sha512-DNdEZABrx2oNSpqijJHjxR/V36hMIQgFkdgv/iQsJ7xhXhObIrH1FMXsd3jbnlgblTc/7/hYed6wNKYxxXX0eQ==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "7.0.0-beta.38",
+                "@babel/traverse": "7.0.0-beta.38",
+                "@babel/types": "7.0.0-beta.38"
+            }
+        },
         "@babel/register": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.40.tgz",
-            "integrity": "sha512-/9ATJf2/YN6MyU1FvagOEh8BhYrCMZRHYgmRPX9T+w0w5ALM8hXCCzmdlxz70dxDfLrf+h4UoFhIdAb+FC8nOw==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.38.tgz",
+            "integrity": "sha512-szE2vMZ8FB6NkywESqDGcAtchQafaWLQgJo3xro7GIgNRmJoAX2xZijU1e5AKT4zWkRRc53aBBwfZy03aWsPgw==",
             "dev": true,
             "requires": {
                 "core-js": "2.5.3",
                 "find-cache-dir": "1.0.0",
                 "home-or-tmp": "3.0.0",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "mkdirp": "0.5.1",
                 "pirates": "3.0.2",
                 "source-map-support": "0.4.18"
             }
         },
         "@babel/template": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
-            "integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.38.tgz",
+            "integrity": "sha512-ygOSe1+ekKVkn5zxCH0rqv5sZtvLfC72yPQSaXLTHtYSYdAyXNqOW7q1ua1zJll9glk0UWYAnUEcehQXXc3fEA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.40",
-                "@babel/types": "7.0.0-beta.40",
-                "babylon": "7.0.0-beta.40",
-                "lodash": "4.17.4"
+                "@babel/code-frame": "7.0.0-beta.38",
+                "@babel/types": "7.0.0-beta.38",
+                "babylon": "7.0.0-beta.38",
+                "lodash": "4.17.5"
             }
         },
         "@babel/traverse": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
-            "integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.38.tgz",
+            "integrity": "sha512-qbrc59aPCnMCj3uroG7QXdFMmrFLFvEfcwfVzmF2MXh2a7OhRzs73g/PNN8Xb0W/4Z1H4ZTY95CczmfDmXapnw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.40",
-                "@babel/generator": "7.0.0-beta.40",
-                "@babel/helper-function-name": "7.0.0-beta.40",
-                "@babel/types": "7.0.0-beta.40",
-                "babylon": "7.0.0-beta.40",
+                "@babel/code-frame": "7.0.0-beta.38",
+                "@babel/generator": "7.0.0-beta.38",
+                "@babel/helper-function-name": "7.0.0-beta.38",
+                "@babel/types": "7.0.0-beta.38",
+                "babylon": "7.0.0-beta.38",
                 "debug": "3.1.0",
                 "globals": "11.3.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
+                "invariant": "2.2.3",
+                "lodash": "4.17.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "@babel/types": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
-            "integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.38.tgz",
+            "integrity": "sha512-SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==",
             "dev": true,
             "requires": {
                 "esutils": "2.0.2",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "to-fast-properties": "2.0.0"
             }
         },
@@ -234,9 +247,9 @@
             }
         },
         "argparse": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
                 "sprintf-js": "1.0.3"
@@ -298,7 +311,7 @@
             "dev": true,
             "requires": {
                 "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.0",
+                "babel-generator": "6.26.1",
                 "babel-helpers": "6.24.1",
                 "babel-messages": "6.23.0",
                 "babel-register": "6.26.0",
@@ -310,7 +323,7 @@
                 "convert-source-map": "1.5.1",
                 "debug": "2.6.9",
                 "json5": "0.5.1",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "minimatch": "3.0.4",
                 "path-is-absolute": "1.0.1",
                 "private": "0.1.8",
@@ -323,22 +336,13 @@
                     "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
                 }
             }
         },
         "babel-generator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-            "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+            "version": "6.26.1",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
                 "babel-messages": "6.23.0",
@@ -346,7 +350,7 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             },
@@ -379,21 +383,21 @@
             }
         },
         "babel-plugin-macros": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.0.0.tgz",
-            "integrity": "sha512-MSsoNjn8yLe3s71m4THcOXn1ZKXVHVpKNoRKCAEUe9mrkECAazW+ON5lJnjMPAuAPllAPh/WaUqoSduMu1//ew==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.2.0.tgz",
+            "integrity": "sha512-HGdenPU9+WGhg++P65O+6aIdmXx99p58K7VtAtizC3eUHbO4FXfyfK9SCJubylcyKziEB3nMAUDFHeyDUj38eA==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "3.1.0"
+                "cosmiconfig": "4.0.0"
             }
         },
         "babel-plugin-preval": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-1.6.3.tgz",
-            "integrity": "sha512-c33fXpCx7H/ESwAKuPu8wcYNh6zoS1kqTcQGW/I8ObOOIx7LgYo2SN1OfiRd3AppsDxbISJjrlVnyydEfWwT0A==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-preval/-/babel-plugin-preval-1.6.4.tgz",
+            "integrity": "sha512-XuNaiZ76CsdWialH2co05YRra9NlsyriTUbJ+56MAcWN9v33drTm5ovBRFuEKVj1dNRhEdBjeEyYtkkaRE8drw==",
             "dev": true,
             "requires": {
-                "babel-plugin-macros": "2.0.0",
+                "babel-plugin-macros": "2.2.0",
                 "babel-register": "6.26.0",
                 "babylon": "6.18.0",
                 "require-from-string": "2.0.1"
@@ -417,7 +421,7 @@
                 "babel-runtime": "6.26.0",
                 "core-js": "2.5.3",
                 "home-or-tmp": "2.0.0",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "mkdirp": "0.5.1",
                 "source-map-support": "0.4.18"
             },
@@ -454,7 +458,7 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.4"
+                "lodash": "4.17.5"
             },
             "dependencies": {
                 "babylon": {
@@ -478,8 +482,8 @@
                 "babylon": "6.18.0",
                 "debug": "2.6.9",
                 "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
+                "invariant": "2.2.3",
+                "lodash": "4.17.5"
             },
             "dependencies": {
                 "babylon": {
@@ -487,15 +491,6 @@
                     "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
                     "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
                     "dev": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
                 },
                 "globals": {
                     "version": "9.18.0",
@@ -513,7 +508,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "to-fast-properties": "1.0.3"
             },
             "dependencies": {
@@ -526,9 +521,9 @@
             }
         },
         "babylon": {
-            "version": "7.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-            "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+            "version": "7.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.38.tgz",
+            "integrity": "sha512-ukc+RoVsxNjsFGTgXtCGr/RcNHQ4/OKBZQ2B6C2XBQwrbxXGWxgOMF9xgQ2WAQJQtvur3N6xakpIGMRNfGtt8Q==",
             "dev": true
         },
         "balanced-match": {
@@ -571,9 +566,9 @@
             }
         },
         "browser-stdout": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
         "chalk": {
@@ -638,7 +633,7 @@
         },
         "commander": {
             "version": "2.11.0",
-            "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commander/-/commander-2.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
             "dev": true
         },
@@ -672,14 +667,14 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cosmiconfig": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-            "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+            "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
             "dev": true,
             "requires": {
                 "is-directory": "0.3.1",
-                "js-yaml": "3.10.0",
-                "parse-json": "3.0.0",
+                "js-yaml": "3.11.0",
+                "parse-json": "4.0.0",
                 "require-from-string": "2.0.1"
             }
         },
@@ -689,9 +684,9 @@
             "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -1895,9 +1890,9 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "invariant": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-            "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+            "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
             "dev": true,
             "requires": {
                 "loose-envify": "1.3.1"
@@ -2032,12 +2027,12 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-            "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.9",
+                "argparse": "1.0.10",
                 "esprima": "4.0.0"
             }
         },
@@ -2045,6 +2040,12 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
             "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+            "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
             "dev": true
         },
         "json5": {
@@ -2073,9 +2074,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "version": "4.17.5",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
             "dev": true
         },
         "lodash._basecopy": {
@@ -2252,12 +2253,12 @@
             }
         },
         "mocha": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
-            "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.2.tgz",
+            "integrity": "sha512-nmlYKMRpJZLxgzk0bRhcvlpjSisbi0x1JiRl7kctadOMPmecUie7WwCZmcyth+PzX5txKbpcMIvDZCAlx9ISxg==",
             "dev": true,
             "requires": {
-                "browser-stdout": "1.3.0",
+                "browser-stdout": "1.3.1",
                 "commander": "2.11.0",
                 "debug": "3.1.0",
                 "diff": "3.3.1",
@@ -2269,6 +2270,15 @@
                 "supports-color": "4.4.0"
             },
             "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
                 "supports-color": {
                     "version": "4.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
@@ -2406,12 +2416,13 @@
             }
         },
         "parse-json": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-            "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.1"
             }
         },
         "path-exists": {
@@ -2769,19 +2780,19 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.8.tgz",
-            "integrity": "sha512-X0jAGtpSZRtd4RhbVNuGHyjZNa/h2MrVkKrR3Ew5iL2MJw6d7FmBke+fhVCALWySv1ygHnjjROG1KI1FAPvddw==",
+            "version": "3.3.13",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.13.tgz",
+            "integrity": "sha512-7rdn/bDOG1ElSTPdh7AI5TCjLv63ZD4k8BBadN3ssIkhlaQL2c0yRxmXCyOYhZK0wZTgGgUSnYQ4CGu+Jos5cA==",
             "dev": true,
             "requires": {
-                "commander": "2.13.0",
+                "commander": "2.14.1",
                 "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.13.0",
-                    "resolved": "https://nexus.cwscloud.net/repository/npm-registry/commander/-/commander-2.13.0.tgz",
-                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+                    "version": "2.14.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+                    "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
                     "dev": true
                 },
                 "source-map": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "through2": "*"
     },
     "devDependencies": {
-        "@babel/cli": "7.0.0-beta.38",
-        "@babel/core": "7.0.0-beta.38",
-        "@babel/register": "7.0.0-beta.38",
+        "@babel/cli": "^7.0.0-beta.38",
+        "@babel/core": "^7.0.0-beta.38",
+        "@babel/register": "^7.0.0-beta.38",
         "babel-plugin-preval": "^1.6.3",
         "mocha": ">=4.0.0",
         "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "through2": "*"
     },
     "devDependencies": {
-        "@babel/cli": "7.0.0-beta.40",
-        "@babel/core": "7.0.0-beta.40",
-        "@babel/register": "7.0.0-beta.40",
+        "@babel/cli": "7.0.0-beta.38",
+        "@babel/core": "7.0.0-beta.38",
+        "@babel/register": "7.0.0-beta.38",
         "babel-plugin-preval": "^1.6.3",
         "mocha": ">=4.0.0",
         "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@babel/core": "^7.0.0-beta.38",
         "@babel/register": "^7.0.0-beta.38",
         "babel-plugin-preval": "^1.6.3",
-        "mocha": ">=4.0.0",
+        "mocha": "^4.1.0",
         "rimraf": "^2.6.2",
         "slash": "^1.0.0",
         "uglify-js": "^3.3.8"

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "through2": "*"
     },
     "devDependencies": {
-        "@babel/cli": "^7.0.0-beta.38",
-        "@babel/core": "^7.0.0-beta.38",
-        "@babel/register": "^7.0.0-beta.38",
+        "@babel/cli": "7.0.0-beta.40",
+        "@babel/core": "7.0.0-beta.40",
+        "@babel/register": "7.0.0-beta.40",
         "babel-plugin-preval": "^1.6.3",
         "mocha": ">=4.0.0",
         "rimraf": "^2.6.2",


### PR DESCRIPTION
Pin versions of babel packages so that dev installs are compatible with npm v2.15.11 for testing on node v4

This will fix the problem with the build for PR #6 (I think).

@fidian Btw, node version 4 reaches End-Of-Life on 2018-04-30 [(reference)](https://github.com/nodejs/Release#release-schedule). What do you think about stopping supporting it here at that time as well?