### PR TITLE
Drop node version 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
     - "6"
+    - "8"
+    - "9"
 notifications:
     irc:
         channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    - "4"
-    - "5"
     - "6"
 notifications:
     irc:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "license": "MIT",
     "engines": {
-        "node": ">=4"
+        "node": ">=6"
     },
     "scripts": {
         "test": "mocha --require @babel/register",


### PR DESCRIPTION
As discussed in PR #7 

> node version 4 reaches End-Of-Life on 2018-04-30 [(reference)](https://github.com/nodejs/Release#release-schedule)

Also dropped support for node version 5 since it reached EOL on 2016-06-30.

Also added configuration to run tests on the latest node versions (8, current LTS, and 9, latest), since they should be (and supposedly are) supported. Node version 7 is already EOL as of 2017-06-30


